### PR TITLE
chore(deps-dev): move to TypeScript 6.0.3 and pin off 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,9 @@ updates:
       # deliberately rather than as a routine PR.
       - dependency-name: lit
         update-types: [version-update:semver-major]
+      # TypeScript 7 dropped the JavaScript Compiler API that declaration
+      # bundling depends on, and API Extractor cannot resolve DOM lib symbols
+      # without it. Adopting 7.x today would cost the single bundled
+      # dist/index.d.ts that RELEASING.md advertises. See issue #6.
+      - dependency-name: typescript
+        update-types: [version-update:semver-major]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/api-extractor": "^7.58.12",
         "@types/node": "^26.2.0",
         "happy-dom": "^20.11.2",
-        "typescript": "^5.6.3",
+        "typescript": "^6.0.3",
         "vite": "^8.2.1",
         "vite-plugin-dts": "^5.0.3",
         "vite-plugin-lib-inject-css": "^2.2.2",
@@ -308,6 +308,20 @@
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
         "@rushstack/node-core-library": "5.23.3"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -2113,9 +2127,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@microsoft/api-extractor": "^7.58.12",
     "@types/node": "^26.2.0",
     "happy-dom": "^20.11.2",
-    "typescript": "^5.6.3",
+    "typescript": "^6.0.3",
     "vite": "^8.2.1",
     "vite-plugin-dts": "^5.0.3",
     "vite-plugin-lib-inject-css": "^2.2.2",


### PR DESCRIPTION
Closes #6. Supersedes #2.

The 5.x line is finished — 5.9.3 shipped 2025-09-30 with nothing after it — so the choice was not "upgrade or stay current", it was "upgrade or stay a year stale".

TypeScript 6 is the last version that still ships the JavaScript Compiler API that declaration bundling depends on, which is exactly why `@typescript/typescript6` exists as the fallback the 7.x error message points at. Full evidence for why 7.x is blocked is on #2.

Also ignores `typescript` majors in `.github/dependabot.yml`, mirroring the existing `lit` rule, so 7.x stops arriving as a permanently red PR while 6.x patches keep flowing.

Verified locally before pushing:

- `make verify` green, 115/115 tests
- declarations still bundle to a single `dist/index.d.ts` (the guard that fails at 14 files did not fire)

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] Tests cover the change (`make verify` passes)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behavior changed — none needed; no user-facing surface changes