### PR TITLE
chore(release): v0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 Include the standalone CSS and JavaScript bundles directly via `<script>` tag:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.1.0/dist/lcars.css" />
-<script src="https://unpkg.com/@no42-org/lcars-47@0.1.0/dist/lcars.iife.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.css" />
+<script src="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.iife.js"></script>
 ```
 
 All custom elements are automatically registered, and utility functions are available under `window.Lcars`.
@@ -64,10 +64,10 @@ All custom elements are automatically registered, and utility functions are avai
   <head>
     <meta charset="UTF-8" />
     <title>LCARS Console</title>
-    <link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.1.0/dist/lcars.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.css" />
     <!-- The IIFE bundle is self-contained. The ESM entry externalizes lit, so
          it needs a bundler (or an import map) rather than a plain script tag. -->
-    <script src="https://unpkg.com/@no42-org/lcars-47@0.1.0/dist/lcars.iife.js"></script>
+    <script src="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.iife.js"></script>
   </head>
   <body>
     <lcars-frame theme="tng">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@no42-org/lcars-47",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Modern, accessible LCARS Web Component library and design token system",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-export const VERSION = '0.1.0';
+export const VERSION = '0.0.1';
 
 export type LcarsEraTheme = 'tng' | 'ds9' | 'nemesis' | 'contrast';
 

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -24,7 +24,7 @@ describe('LCARS Design Tokens & Theme Manager', () => {
   });
 
   it('exports valid version and supported theme list', () => {
-    expect(VERSION).toBe('0.1.0');
+    expect(VERSION).toBe('0.0.1');
     expect(LCARS_THEMES).toEqual(['tng', 'ds9', 'nemesis', 'contrast']);
     expect(LCARS_THEME_ALIASES).toEqual({
       voyager: 'ds9',


### PR DESCRIPTION
Closes #8.

Version bump for the first tagged release. Touches every place the version appears:

| File | Change |
| :--- | :--- |
| `package.json` | `0.1.0` -> `0.0.1` |
| `package-lock.json` | both root entries |
| `src/theme.ts` | `VERSION` constant the library self-reports |
| `test/tokens.test.ts` | the assertion guarding that constant |
| `README.md` | four pinned unpkg URLs |

Verified locally: `make verify` green, 115/115, and the built `dist/index.d.ts` self-reports `0.0.1`.

Tagging this commit once merged triggers the release workflow, which has never run before — this is also the first end-to-end exercise of SBOM generation, cosign keyless signing and SLSA provenance.

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make verify` passes locally
- [x] Tests cover the change (the VERSION assertion fails on a partial bump)
- [x] Commits are signed off (DCO) and follow Conventional Commits
- [x] Docs updated where behaviour changed (README CDN pins)