### PR TITLE
fix(ci): sign the checksums with a cosign v3 bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,12 @@ jobs:
           tmp="$(mktemp)"
           find . -type f -print0 | sort -z | xargs -0 sha256sum > "$tmp"
           mv "$tmp" checksums.txt
+          # cosign v3 emits a Sigstore bundle carrying both the signature and
+          # the certificate. Passing only --output-signature/--output-certificate
+          # leaves the bundle path empty and fails with
+          # "create bundle file: open : no such file or directory".
           cosign sign-blob --yes \
-            --output-signature checksums.txt.sig \
-            --output-certificate checksums.txt.pem \
+            --bundle checksums.txt.bundle \
             checksums.txt
 
       - name: Attest build provenance

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,7 +40,7 @@ Prerelease tags (`vX.Y.Z-rc1`) are detected by the hyphen and marked `--prerelea
 | `index.d.ts` | Bundled TypeScript declarations for the whole public API |
 | `sbom.spdx.json` | SPDX software bill of materials |
 | `checksums.txt` | SHA-256 of every other asset |
-| `checksums.txt.sig` / `.pem` | cosign keyless signature and certificate |
+| `checksums.txt.bundle` | cosign keyless Sigstore bundle (signature + certificate) |
 
 ## Verifying a release
 
@@ -48,11 +48,12 @@ Checksums are signed with cosign keyless (GitHub OIDC), so verification needs no
 
 ```bash
 cosign verify-blob checksums.txt \
-  --signature checksums.txt.sig \
-  --certificate checksums.txt.pem \
+  --bundle checksums.txt.bundle \
   --certificate-identity-regexp 'https://github.com/no42-org/lcars-47/\.github/workflows/release\.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
+
+cosign v3 emits a single Sigstore bundle rather than separate `.sig` and `.pem` files.
 
 Then confirm the artifact you downloaded appears in the verified `checksums.txt`:
 


### PR DESCRIPTION
The first-ever release run (tag `v0.0.1`) failed at the signing step:

```
Error: signing checksums.txt: create bundle file: open : no such file or directory
```

`sigstore/cosign-installer` pulls cosign v3, which emits a Sigstore bundle containing both the signature and the certificate. Passing only `--output-signature`/`--output-certificate` leaves the bundle path empty, and cosign fails writing to it.

Switches to `--bundle`, and updates the RELEASING.md asset table and `verify-blob` command in the same change so the documented verification matches what the pipeline produces.

No release was published — the run failed before the release-creation step, so there is no partial draft to clean up. The `v0.0.1` tag will be re-pointed at the merge of this fix.

## Checklist

- [x] `make verify` passes locally
- [x] actionlint and zizmor clean locally
- [x] Docs updated where behaviour changed (RELEASING.md, same commit)