### PR TITLE
docs: add funding links, Support section and SPONSORS.md

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Donations only. No reward tiers, perks, or promotional placements — this
+# library is LGPL-3.0-or-later and is fully usable with or without a donation.
+github: [indigo423]
+ko_fi: indigo423

--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ unmuteAudio();
 
 ---
 
+## Support
+
+This library is free software under [LGPL-3.0-or-later](LICENSE), and stays that way whether or not anyone donates. Nothing here is gated, time-limited, or held back for supporters.
+
+If it saves you time and you would like to put something toward its upkeep — releases, security fixes, issue triage, and keeping the docs honest — there are two one-off options:
+
+- [GitHub Sponsors](https://github.com/sponsors/indigo423)
+- [Ko-fi](https://ko-fi.com/indigo423)
+
+There are no reward tiers and no perks attached: a donation buys a thank-you and, if you want it, your name in [SPONSORS.md](SPONSORS.md). Nothing more, deliberately.
+
+Not everything useful costs money. A clear bug report with a reproduction, a documentation fix, or simply telling someone the project exists all help just as much.
+
+---
+
 ## License
 
 LGPL-3.0-or-later. Copyright 2026 Ronny Trommer <ronny@no42.org>.

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,31 @@
+<!--
+Copyright 2026 Ronny Trommer <ronny@no42.org>
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Sponsors
+
+Thank you to everyone who has chipped in toward keeping this maintained.
+
+This page is a thank-you, nothing more. Donations here buy no tiers, no perks, no priority support, and no influence over the roadmap — and nothing in this project is ever gated behind them. The library is [LGPL-3.0-or-later](LICENSE) and stays that way.
+
+## Supporters
+
+<!--
+Add names or handles as people give, newest last, one per line:
+
+- [@handle](https://github.com/handle)
+- Someone who preferred not to be linked
+
+Keep this a plain acknowledgment list. No logos, no promotional links, no
+ranking by amount — those turn a donation into a paid placement, which is a
+different thing entirely, both ethically and for VAT.
+-->
+
+No sponsors listed yet. If you have donated and would like to be named here, or named differently, or removed, open an issue or email <ronny@no42.org> — being listed is opt-in and reversible.
+
+## Supporting the project
+
+See [Support](README.md#support) in the README for the current options.
+
+Contributions of time are worth as much as money: a good bug report with a reproduction, a fix, a documentation correction, or telling someone else the project exists. None of that costs anything and all of it helps.


### PR DESCRIPTION
Closes #11.

Adds `.github/FUNDING.yml`, a README **Support** section, and a `SPONSORS.md` acknowledgment list.

## Handles

| Handle | Verification |
| :--- | :--- |
| `github: indigo423` | GraphQL: `hasSponsorsListing=true`, `isPublic=true` |
| `ko_fi: indigo423` | Declared in four sibling repos (blittermib, CoolModFiles, blitsbom, netbox-opennms-plugin). Direct fetch returns 403 from Cloudflare — bot protection, not a missing page |

## Framing

Donation-only, no counter-performance: no tiers, perks, priority support, or promotional logo placement. That keeps a plain donation outside VAT, whereas rewards or ad-style placement can make it a taxable supply and drag in the EU OSS scheme. The library is LGPL-3.0-or-later and stays fully usable with or without a donation — nothing is gated.

`SPONSORS.md` lists nobody rather than inventing names; the available token lacks `read:user` to enumerate sponsors, and being listed is opt-in and reversible.

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make verify` passes locally
- [x] FUNDING.yml parses, keys recognized, no placeholders
- [x] Commits are signed off (DCO) and follow Conventional Commits