### PR TITLE
feat(ci): publish to GitHub Packages and correct the install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write # create the release and upload assets
+      packages: write # publish to GitHub Packages
       id-token: write # cosign keyless signing
       attestations: write # SLSA build provenance
     steps:
@@ -48,6 +49,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+          # Writes the .npmrc that points the scope at GitHub Packages and
+          # reads NODE_AUTH_TOKEN when publishing.
+          registry-url: https://npm.pkg.github.com
+          scope: '@no42-org'
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -108,3 +113,23 @@ jobs:
             gh release create "$TAG" --draft --verify-tag \
               --title "$TAG" --notes "Release notes pending." $PRE
           find release -type f -exec gh release upload "$TAG" --clobber {} +
+
+      # Last, because publishing is the one irreversible step here: a version
+      # cannot be re-published once taken. Everything else has been verified by
+      # the time this runs.
+      #
+      # Publishes the exact tarball that was checksummed, signed and attested,
+      # rather than repacking, so the artifact users install is the one the
+      # signature covers.
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # ./ prefix is required: npm reads a bare "release/x.tgz" as a git
+          # shorthand (owner/repo) and tries to clone it.
+          tarball="$(find ./release -name '*.tgz' -type f)"
+          case "$TAG" in
+            *-*) npm publish "$tarball" --tag next ;;
+            *)   npm publish "$tarball" ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -29,7 +29,19 @@ Authentic Star Trek LCARS (Library Computer Access / Retrieval System) user inte
 
 ### Package Manager (ESM)
 
-Install via npm:
+The package is published to **GitHub Packages**. Point the scope at that registry once, in an `.npmrc` next to your `package.json`:
+
+```
+@no42-org:registry=https://npm.pkg.github.com
+```
+
+GitHub Packages requires authentication **even for public packages**, so you also need a personal access token with the `read:packages` scope:
+
+```
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Then install as usual:
 
 ```bash
 npm install @no42-org/lcars-47
@@ -43,16 +55,18 @@ import '@no42-org/lcars-47/css';
 import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 ```
 
-### Standalone CDN (IIFE)
+### Standalone bundle (no build tooling, no account)
 
-Include the standalone CSS and JavaScript bundles directly via `<script>` tag:
+If you would rather not authenticate, the release assets are served anonymously. Grab the two files straight from a release:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.css" />
-<script src="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.iife.js"></script>
+<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.css" />
+<script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.iife.js"></script>
 ```
 
-All custom elements are automatically registered, and utility functions are available under `window.Lcars`.
+All custom elements are registered automatically, and the utility functions are available under `window.Lcars`.
+
+For production, download the files and serve them yourself rather than hot-linking, and verify them first — every release ships signed checksums, see [RELEASING.md](RELEASING.md).
 
 ---
 
@@ -64,10 +78,10 @@ All custom elements are automatically registered, and utility functions are avai
   <head>
     <meta charset="UTF-8" />
     <title>LCARS Console</title>
-    <link rel="stylesheet" href="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.css" />
+    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.css" />
     <!-- The IIFE bundle is self-contained. The ESM entry externalizes lit, so
          it needs a bundler (or an import map) rather than a plain script tag. -->
-    <script src="https://unpkg.com/@no42-org/lcars-47@0.0.1/dist/lcars.iife.js"></script>
+    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.iife.js"></script>
   </head>
   <body>
     <lcars-frame theme="tng">

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,8 +67,16 @@ Build provenance for the npm tarball is attested to the GitHub attestation store
 gh attestation verify no42-org-lcars-47-X.Y.Z.tgz --repo no42-org/lcars-47
 ```
 
+## Where the package is published
+
+The release workflow publishes to **GitHub Packages** (`npm.pkg.github.com`) as its last step, after every other step has succeeded — publishing is the one action here that cannot be undone, since a version number cannot be reused.
+
+It publishes the **exact tarball** that was checksummed, signed and attested, rather than repacking, so what a user installs is what the signature covers. Authentication uses the built-in `GITHUB_TOKEN`; there is no registry secret to manage. Prerelease tags publish under the `next` dist-tag so they never become `latest`.
+
+Consumers must authenticate to install from GitHub Packages, **even though the package is public** — that is a registry limitation, not a licensing one. The README documents the `.npmrc` this needs, and points anyone who would rather not authenticate at the release assets, which serve anonymously.
+
 ## Not yet wired up
 
-**Publishing to the npm registry.** The release workflow builds and signs the tarball but does not `npm publish` it. Doing so needs an `NPM_TOKEN` secret and a deliberate decision to make the package public, since the repository is currently private. When that happens, publish with `--provenance` so npm carries the same attestation, and document the registry URL here.
+**Publishing to npmjs.com.** Would make `npm install` work with no `.npmrc` and no token, and would light up the unpkg and jsDelivr CDN paths, which mirror npmjs.com only and cannot serve GitHub Packages. It needs an npm account and an `NPM_TOKEN` secret. Publish with `--provenance` so npm carries the same SLSA attestation this pipeline already produces.
 
 **Preview builds from `main`.** The audit checklist expects a rolling preview. This project ships no container image, so the useful equivalent is a `preview` prerelease refreshed on each push to `main`. Not implemented yet.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,10 @@
     "vitest": "^4.1.10"
   },
   "license": "LGPL-3.0-or-later",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "author": "Ronny Trommer <ronny@no42.org>",
   "dependencies": {
     "lit": "^3.3.3"


### PR DESCRIPTION
Closes #13.

## Why

The package was never published anywhere, and the README documented two paths that do not work:

- `npm install @no42-org/lcars-47` resolved nothing.
- The CDN snippets pointed at unpkg, which mirrors npmjs.com only — verified **404** for this package.

## What changed

- `publishConfig` targets `npm.pkg.github.com`. The scope already matches the owner (`@no42-org` / `no42-org`), which is the registry’s main constraint, so publishing uses the built-in `GITHUB_TOKEN` and needs **no new secret**.
- The release job gains `packages: write` and publishes **last** — the only irreversible step here, since a version cannot be reused. It publishes the **exact tarball** that was checksummed, signed and attested, so the artifact users install is the one the signature covers. Prereleases publish under `next`.
- README install section documents the `.npmrc` and the token, and states plainly that GitHub Packages requires authentication **even for public packages**.
- A no-account path replaces the broken CDN section, using release assets, which serve anonymously (verified **200**).
- RELEASING.md records where the package lands and keeps npmjs.com as an explicit future decision.

## Caught before it shipped

A local `npm publish --dry-run` failed with `code 128 / unknown git error`: npm reads a bare `release/x.tgz` as a git shorthand (`owner/repo`) and tries to clone it. Fixed with a `./` prefix. That would otherwise have failed in CI at the last step of a release, after the tag was already public.

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make verify` passes locally
- [x] actionlint and zizmor clean
- [x] Publish path exercised with `npm publish --dry-run` (resolves `@no42-org/lcars-47@0.0.1`, 33 files)