### PR TITLE
chore(release): v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 If you would rather not authenticate, the release assets are served anonymously. Grab the two files straight from a release:
 
 ```html
-<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.css" />
-<script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.iife.js"></script>
+<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.css" />
+<script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.iife.js"></script>
 ```
 
 All custom elements are registered automatically, and the utility functions are available under `window.Lcars`.
@@ -78,10 +78,10 @@ For production, download the files and serve them yourself rather than hot-linki
   <head>
     <meta charset="UTF-8" />
     <title>LCARS Console</title>
-    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.css" />
+    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.css" />
     <!-- The IIFE bundle is self-contained. The ESM entry externalizes lit, so
          it needs a bundler (or an import map) rather than a plain script tag. -->
-    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.1/lcars.iife.js"></script>
+    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.iife.js"></script>
   </head>
   <body>
     <lcars-frame theme="tng">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@no42-org/lcars-47",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Modern, accessible LCARS Web Component library and design token system",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-export const VERSION = '0.0.1';
+export const VERSION = '0.0.2';
 
 export type LcarsEraTheme = 'tng' | 'ds9' | 'nemesis' | 'contrast';
 

--- a/test/tokens.test.ts
+++ b/test/tokens.test.ts
@@ -24,7 +24,7 @@ describe('LCARS Design Tokens & Theme Manager', () => {
   });
 
   it('exports valid version and supported theme list', () => {
-    expect(VERSION).toBe('0.0.1');
+    expect(VERSION).toBe('0.0.2');
     expect(LCARS_THEMES).toEqual(['tng', 'ds9', 'nemesis', 'contrast']);
     expect(LCARS_THEME_ALIASES).toEqual({
       voyager: 'ds9',


### PR DESCRIPTION
Closes #15.

Version bump for `v0.0.2`, which will be the first release to publish to GitHub Packages.

| File | Change |
| :--- | :--- |
| `package.json` | `0.0.1` -> `0.0.2` |
| `package-lock.json` | both root entries (the third `0.0.2` in the file is the `stackback` dependency, untouched) |
| `src/theme.ts` | `VERSION` constant the library self-reports |
| `test/tokens.test.ts` | the assertion guarding it |
| `README.md` | four pinned release-download URLs |

Verified locally: `make verify` green, 115/115, built `dist/index.d.ts` self-reports `0.0.2`.

## Checklist

- [x] Linked issue exists and is referenced above with a closing keyword
- [x] `make verify` passes locally
- [x] Tests cover the change (the VERSION assertion fails on a partial bump)
- [x] Commits are signed off (DCO) and follow Conventional Commits