### PR TITLE
test(layout): gate geometry in a real browser

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -30,6 +30,9 @@ jobs:
 
       - run: make install
 
+      # The layout gate drives a real browser; happy-dom cannot see geometry.
+      - run: make install-browsers
+
       - run: make verify
 
   workflows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
 
       - run: make install
 
+      # release-build re-runs the full gate, which now includes the browser
+      # layout checks. Without this the release aborts after the PR gates have
+      # already passed.
+      - run: make install-browsers
+
       - run: make release-build
 
       # SBOM must exist before checksums are computed, or it ships unverifiable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,17 @@ LCARS Web Component library. See README.md for usage, CONTRIBUTING.md for proces
 Everything goes through `make`; CI runs the same targets.
 
 ```bash
-make verify      # the gate: typecheck, build, test, dist checks
-make test        # tests only
+make verify      # the gate: typecheck, build, test, dist and layout checks
+make test        # unit tests only, no browser
+make test-layout # browser layout gate only
 make dev         # workbench at index.html
 ```
 
 Single test file: `npx vitest run test/keypad.test.ts`. Single case: add `-t "part of the name"`.
 
 `make verify` builds **before** testing on purpose — `test/dist.test.ts` skips its assertions when `dist/` is absent, so reordering silently drops five checks.
+
+Geometry is invisible to `make test`: happy-dom has no layout engine, so every `getBoundingClientRect()` there is zero. `test/layout.test.ts` runs from its own config (`vitest.layout.config.ts`, node environment) and measures the workbench in headless Chromium. It needs `make install-browsers` once, and fails rather than skips without it.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,15 +43,20 @@ Write the body to explain *why*, wrapped at ~72 columns. What changed is already
 Everything runs through `make`; CI calls the same targets, so local and CI cannot drift.
 
 ```bash
-make install     # install from the lockfile
-make verify      # the full gate: typecheck, build, tests, dist checks
-make dev         # workbench dev server at index.html
-make test-watch  # tests in watch mode
+make install          # install from the lockfile
+make install-browsers # once: the browser the layout gate drives
+make verify           # the full gate: typecheck, build, tests, dist and layout checks
+make dev              # workbench dev server at index.html
+make test-watch       # tests in watch mode
+make test-layout      # just the browser layout gate
 ```
 
 Run a single test file with `npx vitest run test/keypad.test.ts`, or a single case with `-t "substring of the test name"`.
 
 `make verify` must pass before you open a PR. It is exactly what CI runs.
+
+The layout gate (`test/layout.test.ts`) drives the workbench in headless Chromium and asserts positions, because the unit suite runs under happy-dom, which has no layout engine and reports every element rectangle as zero.
+It fails rather than skips when the browser is missing, so run `make install-browsers` once after cloning.
 
 ## Conventions worth knowing
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 NPM ?= npm
 
-.PHONY: help install typecheck test test-watch build verify dev clean distclean
+.PHONY: help install install-browsers typecheck test test-watch test-layout build verify dev clean distclean
 
 help: ## Show available targets
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -14,6 +14,9 @@ help: ## Show available targets
 
 install: ## Install dependencies from the lockfile
 	$(NPM) ci
+
+install-browsers: node_modules ## Install the browser the layout gate drives
+	$(NPM) run install:browsers
 
 node_modules: package-lock.json
 	$(NPM) ci
@@ -28,13 +31,19 @@ test: node_modules ## Run the unit test suite once
 test-watch: node_modules ## Run tests in watch mode
 	$(NPM) run test:watch
 
+# Geometry is invisible to the unit suite: happy-dom has no layout engine, so
+# every rect there is zero. This drives the workbench in a real browser and
+# fails, never skips, when that browser is missing.
+test-layout: node_modules ## Run the browser layout gate
+	$(NPM) run test:layout
+
 build: node_modules ## Build ESM + IIFE + CSS + declarations, then verify dist
 	$(NPM) run build
 
 # Build before test on purpose: test/dist.test.ts gates its built-artifact
 # assertions on dist/ existing, so running tests first silently skips them on
 # every clean checkout, which is exactly what CI is.
-verify: typecheck build test ## Full gate: types, build, tests and dist checks
+verify: typecheck build test test-layout ## Full gate: types, build, tests, dist and layout checks
 
 release-build: verify ## Assemble signed-release inputs into release/
 	rm -rf release && mkdir -p release

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@microsoft/api-extractor": "^7.58.12",
         "@types/node": "^26.2.0",
         "happy-dom": "^20.11.2",
+        "playwright": "^1.62.1",
         "typescript": "^6.0.3",
         "vite": "^8.2.1",
         "vite-plugin-dts": "^5.0.3",
@@ -1869,6 +1870,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -39,12 +39,15 @@
     "postbuild": "node scripts/verify-dist.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:layout": "vitest run --config vitest.layout.config.ts",
+    "install:browsers": "playwright install --with-deps chromium"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.12",
     "@types/node": "^26.2.0",
     "happy-dom": "^20.11.2",
+    "playwright": "^1.62.1",
     "typescript": "^6.0.3",
     "vite": "^8.2.1",
     "vite-plugin-dts": "^5.0.3",

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -28,8 +28,13 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createServer, type ViteDevServer } from 'vite';
 import { chromium, type Browser, type Page } from 'playwright';
 
-/** Text that shares a line should share a centre; 1px absorbs sub-pixel layout. */
-const CENTRE_TOLERANCE_PX = 1;
+/**
+ * Slack for sub-pixel layout. Several of these invariants are exact by
+ * construction — the label's padding and the corner radius resolve from the
+ * same token, so the label lands precisely on the arc — and a strict comparison
+ * would fail on a fractional device pixel ratio or a radius expressed in `rem`.
+ */
+const SUBPIXEL_TOLERANCE_PX = 1;
 
 const VIEWPORT = { width: 1440, height: 900 };
 
@@ -56,11 +61,20 @@ beforeAll(async () => {
 
   page = await browser.newPage({ viewport: VIEWPORT });
   await page.goto(url, { waitUntil: 'networkidle' });
-  // Custom elements are registered by a module import; wait for the frame to
-  // have rendered its grid before measuring anything inside it.
-  await page.waitForFunction(
-    () => !!document.querySelector('lcars-frame')?.shadowRoot?.querySelector('.frame-grid')
-  );
+  // Custom elements are registered by a module import, and the frame and the
+  // elbows are separate Lit elements with independently scheduled first
+  // updates. Wait for every shadow root these assertions reach into, or a
+  // measurement can dereference null instead of waiting.
+  await page.waitForFunction(() => {
+    const frame = document.querySelector('lcars-frame');
+    const arch = (slot: string) =>
+      frame?.querySelector(`lcars-elbow[slot="${slot}"]`)?.shadowRoot?.querySelector('.arch');
+    return !!(
+      frame?.shadowRoot?.querySelector('.frame-grid') &&
+      arch('elbow-tl') &&
+      arch('elbow-bl')
+    );
+  });
 }, 120_000);
 
 afterAll(async () => {
@@ -110,7 +124,10 @@ describe('frame and elbow layout', () => {
     const cy = m.headerArch.top + r;
     const inCornerSquare = m.headerLabel.left < cx && m.headerLabel.top < cy;
     const distanceFromArcCentre = Math.hypot(cx - m.headerLabel.left, cy - m.headerLabel.top);
-    const clipped = inCornerSquare && distanceFromArcCentre > r;
+    // The label lands exactly on the arc by construction (its padding and the
+    // radius are the same token), so compare with slack or a fractional pixel
+    // fails a layout that is correct.
+    const clipped = inCornerSquare && distanceFromArcCentre > r + SUBPIXEL_TOLERANCE_PX;
 
     expect(
       clipped,
@@ -121,17 +138,17 @@ describe('frame and elbow layout', () => {
   it('sits the elbow label on the same line as the elbow heading', async () => {
     const m = await measure();
     expect(Math.abs(m.headerLabel.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
-      CENTRE_TOLERANCE_PX
+      SUBPIXEL_TOLERANCE_PX
     );
   });
 
   it('sits the top-bar text on the same line as the elbow heading', async () => {
     const m = await measure();
     expect(Math.abs(m.topBarContent.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
-      CENTRE_TOLERANCE_PX
+      SUBPIXEL_TOLERANCE_PX
     );
     expect(Math.abs(m.topBarBand.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
-      CENTRE_TOLERANCE_PX
+      SUBPIXEL_TOLERANCE_PX
     );
   });
 
@@ -146,7 +163,7 @@ describe('frame and elbow layout', () => {
   it('sits the footer readout on the same line as the footer elbow label', async () => {
     const m = await measure();
     expect(Math.abs(m.footerReadout.centreY - m.footerLabel.centreY)).toBeLessThanOrEqual(
-      CENTRE_TOLERANCE_PX
+      SUBPIXEL_TOLERANCE_PX
     );
     expect(m.footerReadout.left).toBeGreaterThan(m.footerLabel.right);
   });

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Layout invariants, measured in a browser that actually performs layout.
+ *
+ * The unit suite runs under happy-dom, which has no layout engine: every
+ * `getBoundingClientRect()` there is zero, so a frame whose footer sits 175px
+ * below the fold, or an elbow label clipped by its own corner radius, passes it
+ * without complaint. Both shipped that way (#17, #19) and were caught by a human
+ * looking at a screenshot.
+ *
+ * This file drives the workbench in headless Chromium and asserts positions.
+ * It asserts numbers, never pixels: a theme colour or a label's wording must not
+ * be able to break it.
+ *
+ * Known gaps, deliberately not asserted here:
+ *   - The footer row is only checked at 1440x900. At 1280x720 it is currently
+ *     off-screen (#19); that viewport lands with the fix, not with this harness.
+ *   - Scrollbar gutter behaviour is invisible on macOS overlay scrollbars, so it
+ *     is not measured on any platform.
+ *   - Nothing here looks at appearance. A green run is not a visual review.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type ViteDevServer } from 'vite';
+import { chromium, type Browser, type Page } from 'playwright';
+
+/** Text that shares a line should share a centre; 1px absorbs sub-pixel layout. */
+const CENTRE_TOLERANCE_PX = 1;
+
+const VIEWPORT = { width: 1440, height: 900 };
+
+let server: ViteDevServer;
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+  server = await createServer({ server: { port: 0 }, logLevel: 'error' });
+  await server.listen();
+  const url = server.resolvedUrls?.local[0];
+  if (!url) throw new Error('vite dev server did not report a local URL');
+
+  try {
+    browser = await chromium.launch();
+  } catch (cause) {
+    // Never downgrade a missing browser to a skip: a layout gate that quietly
+    // opts out in CI is the same trap as a dist check that fails soft.
+    throw new Error(
+      'Could not launch Chromium for the layout gate. Run `make install-browsers`.',
+      { cause }
+    );
+  }
+
+  page = await browser.newPage({ viewport: VIEWPORT });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  // Custom elements are registered by a module import; wait for the frame to
+  // have rendered its grid before measuring anything inside it.
+  await page.waitForFunction(
+    () => !!document.querySelector('lcars-frame')?.shadowRoot?.querySelector('.frame-grid')
+  );
+}, 120_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await server?.close();
+});
+
+/** Geometry of the workbench, collected in one pass so all of it agrees. */
+async function measure() {
+  return page.evaluate(() => {
+    const box = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right, top: r.top, bottom: r.bottom, centreY: r.top + r.height / 2 };
+    };
+    const frame = document.querySelector('lcars-frame')!;
+    const root = frame.shadowRoot!;
+    const tl = frame.querySelector('lcars-elbow[slot="elbow-tl"]')!;
+    const bl = frame.querySelector('lcars-elbow[slot="elbow-bl"]')!;
+    const arch = tl.shadowRoot!.querySelector('.arch')!;
+
+    return {
+      viewportHeight: window.innerHeight,
+      headerElbow: box(tl),
+      headerArch: box(arch),
+      headerArchRadius: parseFloat(getComputedStyle(arch).borderTopLeftRadius),
+      headerLabel: box(tl.shadowRoot!.querySelector('.label-text')!),
+      headerHeading: box(tl.shadowRoot!.querySelector('.title-text')!),
+      topBarBand: box(root.querySelector('.slot-top-bar')!),
+      topBarContent: box(frame.querySelector('[slot="top-bar"]')!),
+      footerRow: box(root.querySelector('.slot-footer-row')!),
+      footerLabel: box(bl.shadowRoot!.querySelector('.label-text')!),
+      footerReadout: box(frame.querySelector('[slot="footer-readout"]')!),
+    };
+  });
+}
+
+describe('frame and elbow layout', () => {
+  it('keeps the elbow label out of the corner the radius cuts away', async () => {
+    const m = await measure();
+
+    // Within the top-left square of side r, the rounded corner paints only what
+    // is *within* r of the arc centre; everything beyond the arc is cut away.
+    // So the label's nearest corner is safe when it is either past the square
+    // entirely or inside the arc — never in the gap between them.
+    const r = m.headerArchRadius;
+    const cx = m.headerArch.left + r;
+    const cy = m.headerArch.top + r;
+    const inCornerSquare = m.headerLabel.left < cx && m.headerLabel.top < cy;
+    const distanceFromArcCentre = Math.hypot(cx - m.headerLabel.left, cy - m.headerLabel.top);
+    const clipped = inCornerSquare && distanceFromArcCentre > r;
+
+    expect(
+      clipped,
+      `label corner sits ${distanceFromArcCentre.toFixed(1)}px from the arc centre, outside the ${r}px radius`
+    ).toBe(false);
+  });
+
+  it('sits the elbow label on the same line as the elbow heading', async () => {
+    const m = await measure();
+    expect(Math.abs(m.headerLabel.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
+      CENTRE_TOLERANCE_PX
+    );
+  });
+
+  it('sits the top-bar text on the same line as the elbow heading', async () => {
+    const m = await measure();
+    expect(Math.abs(m.topBarContent.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
+      CENTRE_TOLERANCE_PX
+    );
+    expect(Math.abs(m.topBarBand.centreY - m.headerHeading.centreY)).toBeLessThanOrEqual(
+      CENTRE_TOLERANCE_PX
+    );
+  });
+
+  it('leaves a gap between the elbow and the bar text instead of overlapping it', async () => {
+    const m = await measure();
+    // The elbow is sized by its own arch plus heading; the bar must start after
+    // it, not underneath it.
+    expect(m.topBarBand.left).toBeGreaterThan(m.headerElbow.right);
+    expect(m.topBarContent.left).toBeGreaterThan(m.headerElbow.right);
+  });
+
+  it('sits the footer readout on the same line as the footer elbow label', async () => {
+    const m = await measure();
+    expect(Math.abs(m.footerReadout.centreY - m.footerLabel.centreY)).toBeLessThanOrEqual(
+      CENTRE_TOLERANCE_PX
+    );
+    expect(m.footerReadout.left).toBeGreaterThan(m.footerLabel.right);
+  });
+
+  it('keeps the footer row inside the viewport', async () => {
+    const m = await measure();
+    expect(m.footerRow.bottom).toBeLessThanOrEqual(m.viewportHeight);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,12 @@
     "isolatedModules": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "test/**/*", "vite.config.ts", "vitest.config.ts"],
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "vitest.layout.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     include: ['test/**/*.test.ts'],
+    // The layout gate needs a real browser and a real layout engine; it runs
+    // from vitest.layout.config.ts so this suite stays fast and browser-free.
+    exclude: ['**/node_modules/**', '**/dist/**', 'test/layout.test.ts'],
   },
 });

--- a/vitest.layout.config.ts
+++ b/vitest.layout.config.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { defineConfig } from 'vitest/config';
+
+// The layout gate runs in its own config so `make test` stays fast and
+// browser-free: it drives a real browser, so it needs the node environment
+// rather than happy-dom, and generous timeouts for the first browser launch.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/layout.test.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
Closes #20. Groundwork for #19 — no behaviour changes, no `src/` changes.

## Why

happy-dom has no layout engine, so every `getBoundingClientRect()` in the unit suite is zero. #17 (elbow labels clipped by their own corner radius, bar text misaligned and overlapping) and #19 (footer row 175px below the fold) both passed a fully green 115-test suite and were found by a human looking at a screenshot.

## What this adds

`test/layout.test.ts` drives the workbench in headless Chromium and asserts positions:

| assertion | invariant |
| :--- | :--- |
| label clears the cut-away corner | the label's nearest corner is on the painted side of the arc, computed from the live `border-radius` |
| label on the heading line | arch label and elbow heading share a vertical centre |
| bar text on the heading line | top-bar band and its content share that centre too |
| gap, not overlap | the bar starts after the elbow's right edge |
| footer readout on the elbow line | footer label and readout share a centre, in that order |
| footer inside the viewport | footer row bottom ≤ viewport height |

Numeric only, never image snapshots, so a palette or wording change cannot break it.

## Wiring

- Own config (`vitest.layout.config.ts`, node environment) so `make test` stays fast and browser-free; `make verify` runs both.
- `make test-layout` and `make install-browsers`; CI calls the make targets, never Playwright directly.
- Fails with `Run \`make install-browsers\`` when the browser is missing. It never skips — a layout gate that quietly opts out in CI is the same trap as a dist check that fails soft.

## Each assertion was proven to fail

A gate that has never been seen fail proves nothing, so every assertion was checked against the defect it describes.

Restoring `lcars-elbow.ts` from v0.0.2 (pre-#17):

```
× keeps the elbow label out of the corner the radius cuts away
  → label corner sits 31.2px from the arc centre, outside the 28px radius
× sits the elbow label on the same line as the elbow heading
  → expected 2.203125 to be less than or equal to 1
× sits the footer readout on the same line as the footer elbow label
  → expected 2.2109375 to be less than or equal to 1
```

Three targeted frame mutations, each failing exactly one assertion and no others:

| mutation | fails |
| :--- | :--- |
| header band centred in the row | `sits the top-bar text on the same line as the elbow heading` |
| bar band shifted under the elbow | `leaves a gap between the elbow and the bar text` |
| grid taller than the viewport | `keeps the footer row inside the viewport` |

That exercise is also what caught a bug in the test itself: the corner assertion had its inequality inverted and was passing against a label that was demonstrably clipped. It only surfaced because the assertion was run against known-broken code.

## Known gaps, stated in the file

- The footer row is checked at 1440x900 only. At 1280x720 it is off-screen today (#19); that viewport lands with the fix.
- Scrollbar gutter behaviour is unobservable on macOS overlay scrollbars, so it is not asserted on any platform.
- Nothing here looks at appearance. A green run is not a visual review.

## Verification

`make verify`: typecheck, build, `verify-dist OK`, 115 unit tests, 6 layout assertions. Layout gate runs in ~1.4s locally after browser install.

Browser caching in CI is deliberately left out of this PR; worth adding if the install step proves slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)