### PR TITLE
docs(releasing): define the version rule while the major is zero

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,6 +7,18 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 
 Versions follow [SemVer](https://semver.org/), derived from the [Conventional Commits](https://www.conventionalcommits.org/) since the previous tag: a `BREAKING CHANGE` or `!` bumps major, `feat` bumps minor, anything else bumps patch.
 
+**While the major version is `0`, the whole version shifts down one place:**
+
+| commits since the tag | 1.0.0 onward | while `0.x` |
+| :--- | :--- | :--- |
+| `BREAKING CHANGE` or `!` | major | **minor** (`0.0.2` → `0.1.0`) |
+| `feat` | minor | patch (`0.0.2` → `0.0.3`) |
+| anything else | patch | patch (`0.0.2` → `0.0.3`) |
+
+This is [SemVer §4](https://semver.org/#spec-item-4): major version zero is initial development and the public API is not yet stable, so a breaking change costs a minor rather than declaring 1.0.
+Breaking changes still carry a `BREAKING CHANGE:` footer and a `!` in the subject — the footer is the migration note for consumers, independent of which digit moves.
+The table's left column takes over from the first `1.0.0` release.
+
 A release is triggered by **pushing a `vX.Y.Z` tag**. Nothing else publishes.
 
 ## Cutting a release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,17 +7,23 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 
 Versions follow [SemVer](https://semver.org/), derived from the [Conventional Commits](https://www.conventionalcommits.org/) since the previous tag: a `BREAKING CHANGE` or `!` bumps major, `feat` bumps minor, anything else bumps patch.
 
-**While the major version is `0`, the whole version shifts down one place:**
+**While the major version is `0`, every bump costs one digit less, floored at patch:**
 
-| commits since the tag | 1.0.0 onward | while `0.x` |
+| commits since the tag | from `1.0.0` onward | while `0.x` |
 | :--- | :--- | :--- |
 | `BREAKING CHANGE` or `!` | major | **minor** (`0.0.2` → `0.1.0`) |
 | `feat` | minor | patch (`0.0.2` → `0.0.3`) |
 | anything else | patch | patch (`0.0.2` → `0.0.3`) |
 
-This is [SemVer §4](https://semver.org/#spec-item-4): major version zero is initial development and the public API is not yet stable, so a breaking change costs a minor rather than declaring 1.0.
-Breaking changes still carry a `BREAKING CHANGE:` footer and a `!` in the subject — the footer is the migration note for consumers, independent of which digit moves.
-The table's left column takes over from the first `1.0.0` release.
+[SemVer §4](https://semver.org/#spec-item-4) permits this: major version zero is initial development and the public API is not to be considered stable, so a breaking change costs a minor rather than declaring 1.0.
+The spec does not prescribe how to derive bumps within `0.x`; the mapping above is this project's choice.
+
+Two consequences of being in `0.x`, both of which invert the usual reading of a version number:
+
+- A feature release and a bugfix release are indistinguishable by version, and a minor bump means *something broke*, not *something was added*.
+- No row can produce `1.0.0`. Leaving `0.x` is a deliberate decision that the public API is stable, taken by the maintainer, not derived from the commits.
+
+A breaking change carries its `!` or its `BREAKING CHANGE:` footer either way — the marker is the migration note for consumers, independent of which digit it moves.
 
 A release is triggered by **pushing a `vX.Y.Z` tag**. Nothing else publishes.
 


### PR DESCRIPTION
Closes #22.

The rule as written derives the bump straight from Conventional Commits, so the `BREAKING CHANGE:` footer already merged in #18 would make the next release of a `0.0.2` library `1.0.0` — declaring an API stable that #19 is still redesigning.

## The rule

| commits since the tag | 1.0.0 onward | while `0.x` |
| :--- | :--- | :--- |
| `BREAKING CHANGE` or `!` | major | **minor** (`0.0.2` → `0.1.0`) |
| `feat` | minor | patch (`0.0.2` → `0.0.3`) |
| anything else | patch | patch (`0.0.2` → `0.0.3`) |

While the major is zero the whole version shifts down one place. That is [SemVer §4](https://semver.org/#spec-item-4): major version zero is initial development and the public API is not yet stable. The left column takes over from the first `1.0.0`.

Breaking changes still carry the `BREAKING CHANGE:` footer and a `!` in the subject either way — the footer is the migration note for consumers, not the bump instruction. That distinction is stated explicitly, since the two are easy to conflate.

## Effect

The next release is **`0.1.0`**, not `1.0.0`, and stays that way through the #19 contract work.

`RELEASING.md` is the only place the rule is stated (checked `CONTRIBUTING.md`, `AGENTS.md`, `README.md`), so there is nothing to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)