### PR TITLE
fix(frame)!: give the frame a stated height contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ Each of these shipped as a real bug here at least once:
 - **Declaration bundling fails soft.** If `@microsoft/api-extractor` is missing, the build logs "skip bundle declaration files", emits 15 `.d.ts` instead of one, and still exits 0. `verify-dist` catches it; do not weaken that check.
 - **TypeScript is pinned to 6.x deliberately.** 7.x drops the JavaScript Compiler API that declaration bundling needs. See issue #6.
 - **No colour literals in component templates.** Everything resolves through `--lcars-*` tokens, or the era themes stop working.
+- **`<lcars-frame>`'s definite height and its `minmax(0, 1fr)` row are a pair.** The height stops `1fr` resolving to max-content, which pushed the footer row off screen; the `minmax` lets that row shrink below its content when space is tight, which an embedded frame needs. Each looks redundant when tested in the other's regime — delete either and a viewport-sized test suite stays green while a shipped bug comes back.
+- **A flex column with a definite height shrinks its children instead of scrolling.** `overflow: auto` on such a region never fires: content is silently compressed to fit and no scrollbar appears. Scrollable regions need `flex-shrink: 0` on what is slotted into them.
+- **Lit's `adoptedStyleSheets` outrank a `<style>` injected into the shadow root** at equal specificity. An override tried from devtools or a probe script can silently not apply; use `!important` when probing, and check it took.
+- **Backticks inside `css`/`html` templates end the template.** A CSS comment mentioning `` `1fr` `` is a parse error, and the message points at the number, not the comment.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The frame is a **viewport shell**: it is exactly `--lcars-frame-height` tall (`1
 | header and footer bars | fixed chrome, never scroll |
 | the page itself | does not scroll — the frame already fills the viewport |
 
+That last row assumes the host page zeroes its body margin. A default document adds 8px around a `100dvh` frame, which is enough to make the page scroll on top of the frame's own scrolling regions.
+
 To put a frame inside a container instead of the viewport, give it a height and set the property:
 
 ```html
@@ -161,6 +163,8 @@ To put a frame inside a container instead of the viewport, give it a height and 
   <lcars-frame style="--lcars-frame-height: 100%"> … </lcars-frame>
 </div>
 ```
+
+Embedding is sized for viewports **above 600px wide**. Below that the frame switches to document flow (see below) on the strength of the *viewport* width, without regard to the size of the box it was given, and an embedded frame will grow past its container. Track that at [#25](https://github.com/no42-org/lcars-47/issues/25).
 
 **Below 600px this reverses.** The frame becomes an ordinary block that flows with the document: regions grow to their natural height and *the page* scrolls, because a phone whose stacked sidebar is taller than half the viewport has no room left for a pinned shell. A host page that sets `overflow: hidden` on `body` must relax it at that width or the footer is clipped away.
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ Responsive 2D CSS grid layout wrapping standard LCARS interfaces.
 - `elbow-tl` shares the header row with `top-bar`, and `elbow-bl` shares the footer row with `footer-readout`: the elbow is placed first and sized by its own arch plus heading, and the bar text follows it on the same line.
 - **Properties**: `theme` (`'tng' | 'ds9' | 'nemesis' | 'contrast'`).
 
+#### Height and scrolling
+
+The frame is a **viewport shell**: it is exactly `--lcars-frame-height` tall (`100dvh` by default), its header, sidebar and footer stay put, and content that does not fit scrolls *inside* the frame rather than pushing it out of shape.
+
+| region | behaviour |
+| :--- | :--- |
+| `main`, `sidebar` | scroll their own content |
+| header and footer bars | fixed chrome, never scroll |
+| the page itself | does not scroll — the frame already fills the viewport |
+
+To put a frame inside a container instead of the viewport, give it a height and set the property:
+
+```html
+<div style="width: 800px; height: 400px">
+  <lcars-frame style="--lcars-frame-height: 100%"> … </lcars-frame>
+</div>
+```
+
+**Below 600px this reverses.** The frame becomes an ordinary block that flows with the document: regions grow to their natural height and *the page* scrolls, because a phone whose stacked sidebar is taller than half the viewport has no room left for a pinned shell. A host page that sets `overflow: hidden` on `body` must relax it at that width or the footer is clipped away.
+
 ### `<lcars-elbow>`
 Curved LCARS corner bracket rendered with CSS radii and a concave inner fillet.
 - **Properties**: `orientation` (`'top-left' | 'bottom-left' | 'top-right' | 'bottom-right'`), `heading`, `label`, `color`.

--- a/index.html
+++ b/index.html
@@ -30,7 +30,20 @@
         box-sizing: border-box;
         /* The frame defaults to a full 100dvh, which overflows this padded
            container and clips the footer row. */
-        --lcars-frame-min-height: calc(100dvh - 24px);
+        --lcars-frame-height: calc(100dvh - 24px);
+      }
+
+      /* Below the breakpoint the frame stops being a pinned shell and flows
+         with the document, so the page has to be allowed to scroll or the
+         footer is simply clipped away. Must follow the rules it overrides. */
+      @media (max-width: 600px) {
+        html,
+        body,
+        .app-container {
+          height: auto;
+          min-height: 100vh;
+          overflow: visible;
+        }
       }
 
       .top-header {
@@ -62,13 +75,15 @@
         margin-bottom: 2px;
       }
 
+      /* The frame's main region owns scrolling now. This used to carry
+         `height: 100%` and its own `overflow-y: auto` to work around a shell
+         that never scrolled; keeping them would mean two nested scrollers, and
+         a percentage height inside an auto-height column breaks the frame's
+         sizing below the breakpoint. */
       .main-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
         gap: 16px;
-        height: 100%;
-        overflow-y: auto;
-        padding-right: 8px;
         box-sizing: border-box;
       }
 

--- a/index.html
+++ b/index.html
@@ -38,11 +38,18 @@
          footer is simply clipped away. Must follow the rules it overrides. */
       @media (max-width: 600px) {
         html,
-        body,
+        body {
+          height: auto;
+          min-height: 100dvh;
+          /* Only the vertical axis opens up. Letting both go visible turns
+             any content wider than the phone into a sideways page scroll,
+             which the shell's overflow: hidden used to mask. */
+          overflow-x: hidden;
+          overflow-y: auto;
+        }
+
         .app-container {
           height: auto;
-          min-height: 100vh;
-          overflow: visible;
         }
       }
 

--- a/src/components/lcars-frame.ts
+++ b/src/components/lcars-frame.ts
@@ -11,31 +11,32 @@ import { LcarsElement } from './base';
  */
 export class LcarsFrame extends LcarsElement {
   static override styles = css`
+    /* The host is the grid. Two boxes each declaring a height is what let the
+       footer row drift off screen: the inner one tracked the outer through
+       hand-maintained arithmetic, and the seam between them was the bug. */
     :host {
-      display: block;
-      width: 100%;
-      min-height: 100vh;
-      min-height: var(--lcars-frame-min-height, 100dvh);
-      background-color: var(--lcars-color-bg, #000000);
-      color: var(--lcars-color-text, #ff9900);
-      font-family: var(--lcars-font-family, 'Antonio', sans-serif);
-      box-sizing: border-box;
-      padding: var(--lcars-gap-md, 8px);
-    }
-
-    .frame-grid {
       display: grid;
       grid-template-columns: var(--lcars-sidebar-width, 160px) 1fr;
-      grid-template-rows: auto 1fr auto;
+      /* The definite height and this minmax are a pair. The height stops 1fr
+         resolving to max-content (which pushed the footer past the viewport);
+         the minmax lets the row shrink below its content when space is tight
+         (embedded, the track overflowed its own frame by 165px). Each looks
+         redundant when tested in the other's regime; deleting either one
+         reinstates a shipped bug. See test/layout.test.ts. */
+      grid-template-rows: auto minmax(0, 1fr) auto;
       grid-template-areas:
         'header  header'
         'sidebar main'
         'footer  footer';
       gap: var(--lcars-gap-sm, 4px);
       width: 100%;
-      min-height: calc(100vh - 2 * var(--lcars-gap-md, 8px));
-      min-height: calc(var(--lcars-frame-min-height, 100dvh) - 2 * var(--lcars-gap-md, 8px));
+      height: 100vh;
+      height: var(--lcars-frame-height, 100dvh);
+      background-color: var(--lcars-color-bg, #000000);
+      color: var(--lcars-color-text, #ff9900);
+      font-family: var(--lcars-font-family, 'Antonio', sans-serif);
       box-sizing: border-box;
+      padding: var(--lcars-gap-md, 8px);
     }
 
     /* The elbow and the bar next to it share one row: the elbow is as wide as
@@ -78,6 +79,9 @@ export class LcarsFrame extends LcarsElement {
       display: flex;
       flex-direction: column;
       gap: var(--lcars-gap-sm, 4px);
+      /* Without this a long control column paints over the pinned footer row
+         and off the bottom of the screen, silently. */
+      overflow: auto;
     }
 
     .slot-main {
@@ -91,16 +95,44 @@ export class LcarsFrame extends LcarsElement {
       overflow: auto;
     }
 
+    /* A flex column shrinks its items to fit rather than overflowing, so
+       the overflow:auto above would never have anything to scroll: content would
+       be compressed to whatever room was left, with no scrollbar to reveal it. */
+    .slot-main slot::slotted(*),
+    .slot-sidebar slot::slotted(*) {
+      flex-shrink: 0;
+    }
+
+    /* Reserve the scrollbar's space at all times, or content shifts sideways
+       the moment a region crosses its scroll threshold. Invisible on overlay
+       scrollbars (macOS), load-bearing on Windows and Linux. */
+    .slot-main,
+    .slot-sidebar {
+      scrollbar-gutter: stable;
+    }
+
     /* Responsive adjustments for narrow screens */
     @media (max-width: 600px) {
-      .frame-grid {
+      /* Deliberate change of identity, not just a reflow: too narrow to be a
+         cockpit, so the frame becomes a document block and the page scrolls.
+         Pinning the shell here starves main — a stacked sidebar taller than
+         half the viewport leaves it its padding and nothing else. */
+      :host {
         grid-template-columns: 1fr;
-        grid-template-rows: auto 1fr auto auto;
+        grid-template-rows: auto auto auto auto;
         grid-template-areas:
           'header'
           'main'
           'sidebar'
           'footer';
+        height: auto;
+        min-height: 100vh;
+        min-height: var(--lcars-frame-height, 100dvh);
+      }
+
+      .slot-main,
+      .slot-sidebar {
+        overflow: visible;
       }
 
       .slot-sidebar {
@@ -126,35 +158,33 @@ export class LcarsFrame extends LcarsElement {
 
   override render(): TemplateResult {
     return html`
-      <div class="frame-grid">
-        <div class="slot-header">
-          <div class="slot-elbow-tl">
-            <slot name="elbow-tl"></slot>
-          </div>
-
-          <div class="slot-top-bar">
-            <slot name="top-bar"></slot>
-          </div>
+      <div class="slot-header">
+        <div class="slot-elbow-tl">
+          <slot name="elbow-tl"></slot>
         </div>
 
-        <aside class="slot-sidebar">
-          <slot name="sidebar"></slot>
-        </aside>
+        <div class="slot-top-bar">
+          <slot name="top-bar"></slot>
+        </div>
+      </div>
 
-        <main class="slot-main">
-          <slot></slot>
-          <slot name="main"></slot>
-        </main>
+      <aside class="slot-sidebar">
+        <slot name="sidebar"></slot>
+      </aside>
 
-        <div class="slot-footer-row">
-          <div class="slot-elbow-bl">
-            <slot name="elbow-bl"></slot>
-          </div>
+      <main class="slot-main">
+        <slot></slot>
+        <slot name="main"></slot>
+      </main>
 
-          <div class="slot-footer">
-            <slot name="footer-readout"></slot>
-            <slot name="footer"></slot>
-          </div>
+      <div class="slot-footer-row">
+        <div class="slot-elbow-bl">
+          <slot name="elbow-bl"></slot>
+        </div>
+
+        <div class="slot-footer">
+          <slot name="footer-readout"></slot>
+          <slot name="footer"></slot>
         </div>
       </div>
     `;

--- a/src/components/lcars-frame.ts
+++ b/src/components/lcars-frame.ts
@@ -30,7 +30,10 @@ export class LcarsFrame extends LcarsElement {
         'footer  footer';
       gap: var(--lcars-gap-sm, 4px);
       width: 100%;
-      height: 100vh;
+      /* No vh fallback: once this substitutes a value the browser cannot parse,
+         the declaration is invalid at computed-value time and the property is
+         unset, not rolled back to an earlier declaration. A guard here could
+         never fire, so the token's default carries the requirement instead. */
       height: var(--lcars-frame-height, 100dvh);
       background-color: var(--lcars-color-bg, #000000);
       color: var(--lcars-color-text, #ff9900);
@@ -126,7 +129,6 @@ export class LcarsFrame extends LcarsElement {
           'sidebar'
           'footer';
         height: auto;
-        min-height: 100vh;
         min-height: var(--lcars-frame-height, 100dvh);
       }
 

--- a/src/tokens/geometry.css
+++ b/src/tokens/geometry.css
@@ -18,6 +18,9 @@
     --lcars-sidebar-width: 160px;
     --lcars-elbow-width: 160px;
     --lcars-elbow-height: 60px;
+    /* Height of a <lcars-frame> shell. Set it to 100% to fill a sized
+       container instead of the viewport. */
+    --lcars-frame-height: 100dvh;
 
     /* Touch Targets */
     --lcars-touch-target-min-width: 80px;

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -335,10 +335,11 @@ describe('LCARS Geometric Framework Components', () => {
       expect(frame.getAttribute('data-lcars-theme')).toBe('ds9');
       // The host itself is the grid: a wrapper would mean two boxes owning the
       // frame's height, which is what pushed the footer row off screen (#19).
-      const styles = (frame.constructor as typeof LcarsFrame).styles?.toString() ?? '';
-      expect(styles).toMatch(/:host\s*\{[^}]*display:\s*grid/);
-      expect(styles).toContain('grid-template-areas');
-      expect(frame.shadowRoot?.querySelector('.frame-grid')).toBeNull();
+      // Asserted structurally, so any re-introduced wrapper fails this whatever
+      // it is called.
+      const main = frame.shadowRoot?.querySelector('.slot-main');
+      expect(main).not.toBeNull();
+      expect(main?.parentNode).toBe(frame.shadowRoot);
     });
 
     it('provides all named layout slots', async () => {

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -333,8 +333,12 @@ describe('LCARS Geometric Framework Components', () => {
       await frame.updateComplete;
 
       expect(frame.getAttribute('data-lcars-theme')).toBe('ds9');
-      const grid = frame.shadowRoot?.querySelector('.frame-grid');
-      expect(grid).not.toBeNull();
+      // The host itself is the grid: a wrapper would mean two boxes owning the
+      // frame's height, which is what pushed the footer row off screen (#19).
+      const styles = (frame.constructor as typeof LcarsFrame).styles?.toString() ?? '';
+      expect(styles).toMatch(/:host\s*\{[^}]*display:\s*grid/);
+      expect(styles).toContain('grid-template-areas');
+      expect(frame.shadowRoot?.querySelector('.frame-grid')).toBeNull();
     });
 
     it('provides all named layout slots', async () => {

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -21,6 +21,9 @@
  *     off-screen (#19); that viewport lands with the fix, not with this harness.
  *   - Scrollbar gutter behaviour is invisible on macOS overlay scrollbars, so it
  *     is not measured on any platform.
+ *   - Embedding is only checked above the narrow breakpoint. Below it the frame
+ *     switches to document flow on viewport width alone and an embedded frame
+ *     outgrows its container (#25).
  *   - Nothing here looks at appearance. A green run is not a visual review.
  */
 

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -37,16 +37,39 @@ import { chromium, type Browser, type Page } from 'playwright';
 const SUBPIXEL_TOLERANCE_PX = 1;
 
 const VIEWPORT = { width: 1440, height: 900 };
+/** Wide enough for the pinned-shell layout, short enough that content overflows. */
+const SHORT_VIEWPORT = { width: 1280, height: 720 };
+/** Below the 600px breakpoint, where the frame becomes a document block. */
+const NARROW_VIEWPORT = { width: 420, height: 720 };
 
 let server: ViteDevServer;
 let browser: Browser;
+let url: string;
 let page: Page;
+
+/** A workbench page at the given viewport, ready to measure. */
+async function openWorkbench(viewport: { width: number; height: number }): Promise<Page> {
+  const p = await browser.newPage({ viewport });
+  await p.goto(url, { waitUntil: 'networkidle' });
+  // Custom elements are registered by a module import, and the frame and the
+  // elbows are separate Lit elements with independently scheduled first
+  // updates. Wait for every shadow root these assertions reach into, or a
+  // measurement can dereference null instead of waiting.
+  await p.waitForFunction(() => {
+    const frame = document.querySelector('lcars-frame');
+    const arch = (slot: string) =>
+      frame?.querySelector(`lcars-elbow[slot="${slot}"]`)?.shadowRoot?.querySelector('.arch');
+    return !!(frame?.shadowRoot?.querySelector('.frame-grid') && arch('elbow-tl') && arch('elbow-bl'));
+  });
+  return p;
+}
 
 beforeAll(async () => {
   server = await createServer({ server: { port: 0 }, logLevel: 'error' });
   await server.listen();
-  const url = server.resolvedUrls?.local[0];
-  if (!url) throw new Error('vite dev server did not report a local URL');
+  const local = server.resolvedUrls?.local[0];
+  if (!local) throw new Error('vite dev server did not report a local URL');
+  url = local;
 
   try {
     browser = await chromium.launch();
@@ -59,22 +82,7 @@ beforeAll(async () => {
     );
   }
 
-  page = await browser.newPage({ viewport: VIEWPORT });
-  await page.goto(url, { waitUntil: 'networkidle' });
-  // Custom elements are registered by a module import, and the frame and the
-  // elbows are separate Lit elements with independently scheduled first
-  // updates. Wait for every shadow root these assertions reach into, or a
-  // measurement can dereference null instead of waiting.
-  await page.waitForFunction(() => {
-    const frame = document.querySelector('lcars-frame');
-    const arch = (slot: string) =>
-      frame?.querySelector(`lcars-elbow[slot="${slot}"]`)?.shadowRoot?.querySelector('.arch');
-    return !!(
-      frame?.shadowRoot?.querySelector('.frame-grid') &&
-      arch('elbow-tl') &&
-      arch('elbow-bl')
-    );
-  });
+  page = await openWorkbench(VIEWPORT);
 }, 120_000);
 
 afterAll(async () => {
@@ -171,5 +179,138 @@ describe('frame and elbow layout', () => {
   it('keeps the footer row inside the viewport', async () => {
     const m = await measure();
     expect(m.footerRow.bottom).toBeLessThanOrEqual(m.viewportHeight);
+  });
+});
+
+/**
+ * The frame's height contract (#19): a viewport shell above the narrow
+ * breakpoint, a document block below it, with every region that receives
+ * content stating whether it scrolls.
+ */
+describe('frame height contract', () => {
+  /** Drops a plain block into `main`, so nothing brings its own scroller. */
+  const TALL_BLOCK_PX = 2000;
+
+  async function withTallMain<T>(viewport: typeof VIEWPORT, read: (p: Page) => Promise<T>): Promise<T> {
+    const p = await openWorkbench(viewport);
+    try {
+      await p.evaluate((height) => {
+        const block = document.createElement('div');
+        block.id = 'tall-block';
+        block.setAttribute('slot', 'main');
+        block.style.cssText = `height: ${height}px; background: #202;`;
+        document.querySelector('lcars-frame')!.appendChild(block);
+      }, TALL_BLOCK_PX);
+      return await read(p);
+    } finally {
+      await p.close();
+    }
+  }
+
+  it('keeps the footer row on screen when main content is taller than the frame', async () => {
+    const r = await withTallMain(SHORT_VIEWPORT, (p) =>
+      p.evaluate(() => {
+        const root = document.querySelector('lcars-frame')!.shadowRoot!;
+        return {
+          footerBottom: root.querySelector('.slot-footer-row')!.getBoundingClientRect().bottom,
+          viewportHeight: window.innerHeight,
+        };
+      })
+    );
+    expect(r.footerBottom).toBeLessThanOrEqual(r.viewportHeight);
+  });
+
+  it('scrolls main rather than compressing what is slotted into it', async () => {
+    const r = await withTallMain(SHORT_VIEWPORT, (p) =>
+      p.evaluate(() => {
+        const main = document.querySelector('lcars-frame')!.shadowRoot!.querySelector('.slot-main')!;
+        return {
+          blockHeight: document.getElementById('tall-block')!.getBoundingClientRect().height,
+          clientHeight: main.clientHeight,
+          scrollHeight: main.scrollHeight,
+        };
+      })
+    );
+    // A flex column shrinks its items to fit unless told otherwise, which
+    // destroys content silently instead of producing a scrollbar.
+    expect(r.blockHeight).toBeCloseTo(TALL_BLOCK_PX, 0);
+    expect(r.scrollHeight).toBeGreaterThan(r.clientHeight);
+  });
+
+  it('stays inside a sized container when embedded with --lcars-frame-height', async () => {
+    const p = await openWorkbench(SHORT_VIEWPORT);
+    try {
+      const r = await p.evaluate(() => {
+        const frame = document.querySelector('lcars-frame')!;
+        const cell = document.createElement('div');
+        cell.style.cssText = 'width: 800px; height: 400px;';
+        document.body.appendChild(cell);
+        cell.appendChild(frame);
+        (frame as HTMLElement).style.setProperty('--lcars-frame-height', '100%');
+
+        const root = frame.shadowRoot!;
+        const cellBottom = cell.getBoundingClientRect().bottom;
+        const main = root.querySelector('.slot-main')!;
+        return {
+          cellHeight: cell.getBoundingClientRect().height,
+          frameHeight: frame.getBoundingClientRect().height,
+          overshoot: root.querySelector('.slot-footer-row')!.getBoundingClientRect().bottom - cellBottom,
+          mainOvershoot: main.getBoundingClientRect().bottom - cellBottom,
+        };
+      });
+      // A definite height alone does not cap the flexible row when space is
+      // tight: the box is right and the track still paints outside it.
+      expect(r.frameHeight).toBeCloseTo(r.cellHeight, 0);
+      expect(r.overshoot).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+      expect(r.mainOvershoot).toBeLessThanOrEqual(SUBPIXEL_TOLERANCE_PX);
+    } finally {
+      await p.close();
+    }
+  });
+
+  it('scrolls the sidebar rather than painting it over the footer', async () => {
+    const p = await openWorkbench(SHORT_VIEWPORT);
+    try {
+      const r = await p.evaluate(async () => {
+        const frame = document.querySelector('lcars-frame')!;
+        const sidebar = frame.querySelector('[slot="sidebar"]')!;
+        const added = Array.from({ length: 30 }, (_, i) => {
+          const b = document.createElement('lcars-button');
+          b.textContent = `SYS ${i}`;
+          sidebar.appendChild(b);
+          return b as HTMLElement & { updateComplete?: Promise<unknown> };
+        });
+        await Promise.all(added.map((b) => b.updateComplete));
+
+        const root = frame.shadowRoot!;
+        const region = root.querySelector('.slot-sidebar')!;
+        return {
+          clientHeight: region.clientHeight,
+          scrollHeight: region.scrollHeight,
+          overflowY: getComputedStyle(region).overflowY,
+          regionBottom: region.getBoundingClientRect().bottom,
+          footerTop: root.querySelector('.slot-footer-row')!.getBoundingClientRect().top,
+        };
+      });
+      expect(r.scrollHeight).toBeGreaterThan(r.clientHeight);
+      expect(r.overflowY).not.toBe('visible');
+      expect(r.regionBottom).toBeLessThanOrEqual(r.footerTop + SUBPIXEL_TOLERANCE_PX);
+    } finally {
+      await p.close();
+    }
+  });
+
+  it('lets main keep its natural height below the narrow breakpoint', async () => {
+    // Guard rather than reproduction: this passes today. Pinning a shell height
+    // on a phone, where the stacked sidebar alone is taller than half the
+    // viewport, collapses main to its padding — the regression the fix could
+    // introduce.
+    const r = await withTallMain(NARROW_VIEWPORT, (p) =>
+      p.evaluate(() => {
+        const main = document.querySelector('lcars-frame')!.shadowRoot!.querySelector('.slot-main')!;
+        return { clientHeight: main.clientHeight, scrollHeight: main.scrollHeight };
+      })
+    );
+    expect(r.clientHeight).toBeGreaterThanOrEqual(r.scrollHeight - SUBPIXEL_TOLERANCE_PX);
   });
 });

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -59,7 +59,7 @@ async function openWorkbench(viewport: { width: number; height: number }): Promi
     const frame = document.querySelector('lcars-frame');
     const arch = (slot: string) =>
       frame?.querySelector(`lcars-elbow[slot="${slot}"]`)?.shadowRoot?.querySelector('.arch');
-    return !!(frame?.shadowRoot?.querySelector('.frame-grid') && arch('elbow-tl') && arch('elbow-bl'));
+    return !!(frame?.shadowRoot?.querySelector('.slot-main') && arch('elbow-tl') && arch('elbow-bl'));
   });
   return p;
 }


### PR DESCRIPTION
Closes #19.

Two commits: the assertions land red first (`e5f5051`), then the fix turns them green (`772089b`).

## The defect

The frame declared two floors and no ceiling — `:host` and `.frame-grid` each carried a `min-height`, kept in step by hand-maintained arithmetic — while `grid-template-rows: auto 1fr auto` needs a *definite* height to have anything to distribute. So `1fr` resolved to max-content, the grid grew past the viewport, and the footer row went with it.

Investigation found five more failures behind that one; the full analysis is in #19.

## Before → after

| | before | after |
| :--- | ---: | ---: |
| footer row at 1280x720, tall main content | 2903px (viewport 720px) | inside the viewport |
| a slotted child asking for 2000px | rendered 1152px, no scrollbar | 2000px, main scrolls |
| frame embedded in a 400px container | 1099px | 400px, nothing outside it |
| sidebar with 30 buttons | `scrollHeight == clientHeight`, painted over the footer | scrolls in its column |

## What changed

**The host is the grid.** `.frame-grid` is gone, and with it the `calc(… - 2 * var(--lcars-gap-md))` that existed only to keep the inner box in step with the outer one. That seam was the bug.

**The definite height and `minmax(0, 1fr)` ship together.** Neither is sufficient: the height stops `1fr` taking max-content, the `minmax` lets the row shrink below its content when space is tight. Testing only a viewport-sized frame makes the `minmax` look redundant — which is exactly how an embedded frame came to overflow its own box by 165px. Both the comment in the source and `AGENTS.md` say so, because this is the line a future contributor will most plausibly simplify away.

**Every content region states whether it scrolls.** `main` and `sidebar` do. A flex column shrinks its children rather than overflowing, so both also carry `flex-shrink: 0` on slotted children — otherwise `overflow: auto` never has anything to scroll and content is silently compressed. Both get `scrollbar-gutter: stable` so crossing the scroll threshold does not shift content sideways (a policy call: unobservable on macOS overlay scrollbars).

**Below 600px the frame changes identity**, not just its arrangement: it becomes a document block and the page scrolls. Pinning a shell on a phone leaves `main` its padding and nothing else once the stacked sidebar is taller than half the viewport. The workbench relaxes its `overflow: hidden` at that width to match, and the README says who scrolls at each size.

**The workbench drops its own inner scroller.** `.main-grid` carried `height: 100%` and `overflow-y: auto` to work around a shell that never scrolled. Two nested scrollers is one too many, and the percentage height broke the frame's sizing below the breakpoint — that is what the narrow-viewport guard caught.

## Breaking change

`--lcars-frame-min-height` is no longer read. Use `--lcars-frame-height`: it sets the shell height rather than a floor, and `100%` is the supported way to fill a sized container. Under the 0.x rule merged in #23 this bumps the minor, so the next release is `0.1.0`.

## Verification

`make verify`: typecheck, build, `verify-dist OK`, 115 unit tests, 11 layout assertions.

Visual pass at 1440x900 (unchanged), 1280x720 (footer now pinned, main scrolling), 420x720 (flows, nothing starved) and embedded in an 800x400 box (fills it exactly, chrome on the container's edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)