### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 If you would rather not authenticate, the release assets are served anonymously. Grab the two files straight from a release:
 
 ```html
-<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.css" />
-<script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.iife.js"></script>
+<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.css" />
+<script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.iife.js"></script>
 ```
 
 All custom elements are registered automatically, and the utility functions are available under `window.Lcars`.
@@ -83,10 +83,10 @@ For production, download the files and serve them yourself rather than hot-linki
   <head>
     <meta charset="UTF-8" />
     <title>LCARS Console</title>
-    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.css" />
+    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.css" />
     <!-- The IIFE bundle is self-contained. The ESM entry externalizes lit, so
          it needs a bundler (or an import map) rather than a plain script tag. -->
-    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.0.2/lcars.iife.js"></script>
+    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.iife.js"></script>
   </head>
   <body>
     <lcars-frame theme="tng">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@no42-org/lcars-47",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Modern, accessible LCARS Web Component library and design token system",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #34.

Bumps the manifest to `0.1.0` so the tag and the package agree. The release workflow fails fast if they do not.

Four of the eight commits since `v0.0.2` carry a breaking change, which bumps the minor while the major is zero (#22).

Also moves the README's standalone-bundle URLs from `v0.0.2` to `v0.1.0`. They are copy-paste instructions in the Quick Start, so leaving them behind would hand new users the build this release exists to replace. They 404 until the release is published, which is minutes after this merges.

`make verify`: 117 unit tests, 23 layout assertions, `verify-dist OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)