### PR TITLE
docs: state that this is an unofficial homage

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,11 @@ Not everything useful costs money. A clear bug report with a reproduction, a doc
 ## License
 
 LGPL-3.0-or-later. Copyright 2026 Ronny Trommer <ronny@no42.org>.
+
+## Trademarks
+
+`Star Trek` and `LCARS` are trademarks of CBS Studios Inc.
+
+This project is an unofficial homage. It is not affiliated with, endorsed by, or sponsored by CBS Studios Inc., Paramount Global, or their subsidiaries. The names are used descriptively, to say what this library reproduces.
+
+The license above covers this source code. It grants nothing in respect of anyone else's trademarks or designs.


### PR DESCRIPTION
Closes #36.

Adds a `Trademarks` section under `License`:

> `Star Trek` and `LCARS` are trademarks of CBS Studios Inc.
>
> This project is an unofficial homage. It is not affiliated with, endorsed by, or sponsored by CBS Studios Inc., Paramount Global, or their subsidiaries. The names are used descriptively, to say what this library reproduces.
>
> The license above covers this source code. It grants nothing in respect of anyone else's trademarks or designs.

The last line is deliberate. A disclaimer is not a licence, and it does not speak to the visual design, which is copyright and trade dress rather than trademark. Saying so is more honest than implying the notice settles more than it does.

Going in before `v0.1.0` is tagged, since the README is what renders on the GitHub Packages page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)