### PR TITLE
feat(site): publish the workbench to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Publishes the workbench (make site) to GitHub Pages. Deliberately does not
+# reuse quality-gates.yml: this workflow trusts that main only advances through
+# gated PRs and runs only the site build itself. That trust is policy, not
+# wiring: a push that bypasses the required checks (admin direct push) still
+# deploys. Accepted over rerunning the full gate (browser install included)
+# on a second runner for every merge.
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Queue rather than cancel: an in-flight deploy interrupted mid-publish can
+# leave the site broken until the next push.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: make install
+
+      - run: make site
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Production build artifacts
 dist/
 release/
+site/
 
 # OS and system files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ LCARS Web Component library. See README.md for usage, CONTRIBUTING.md for proces
 Everything goes through `make`; CI runs the same targets.
 
 ```bash
-make verify      # the gate: typecheck, build, test, dist and layout checks
+make verify      # the gate: typecheck, build, test, dist, layout and site checks
 make test        # unit tests only, no browser
 make test-layout # browser layout gate only
 make dev         # workbench at index.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Everything runs through `make`; CI calls the same targets, so local and CI canno
 ```bash
 make install          # install from the lockfile
 make install-browsers # once: the browser the layout gate drives
-make verify           # the full gate: typecheck, build, tests, dist and layout checks
+make verify           # the full gate: typecheck, build, tests, dist, layout and site checks
 make dev              # workbench dev server at index.html
 make test-watch       # tests in watch mode
 make test-layout      # just the browser layout gate

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 NPM ?= npm
 
-.PHONY: help install install-browsers typecheck test test-watch test-layout build verify dev clean distclean
+.PHONY: help install install-browsers typecheck test test-watch test-layout build site verify dev clean distclean
 
 help: ## Show available targets
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -40,10 +40,15 @@ test-layout: node_modules ## Run the browser layout gate
 build: node_modules ## Build ESM + IIFE + CSS + declarations, then verify dist
 	$(NPM) run build
 
+site: node_modules ## Build the workbench as a static site into site/ (GitHub Pages)
+	$(NPM) run build:site
+
 # Build before test on purpose: test/dist.test.ts gates its built-artifact
 # assertions on dist/ existing, so running tests first silently skips them on
-# every clean checkout, which is exactly what CI is.
-verify: typecheck build test test-layout ## Full gate: types, build, tests, dist and layout checks
+# every clean checkout, which is exactly what CI is. site comes last so that
+# ordering stays undisturbed; it catches workbench breakage in the PR gate,
+# since the Pages deploy workflow runs only make site and no other checks.
+verify: typecheck build test test-layout site ## Full gate: types, build, tests, dist, layout and site checks
 
 release-build: verify ## Assemble signed-release inputs into release/
 	rm -rf release && mkdir -p release
@@ -57,7 +62,7 @@ dev: node_modules ## Start the workbench dev server
 	$(NPM) run dev
 
 clean: ## Remove build output
-	rm -rf dist
+	rm -rf dist site
 
 distclean: clean ## Remove build output and installed dependencies
 	rm -rf node_modules

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Authentic Star Trek LCARS (Library Computer Access / Retrieval System) user inte
 ![The LCARS 47 workbench: live telemetry driving readouts, bargraphs and status pills inside an elbow frame, cycling through the TNG, DS9, Nemesis and high-contrast era palettes](docs/workbench.gif)
 
 The workbench above is `index.html` in this repository, recorded live.
-Run it yourself with `make dev`.
+[Try it in your browser](https://no42-org.github.io/lcars-47/) or run it locally with `make dev`.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dev": "vite",
     "build": "vite build && vite build --mode iife",
     "postbuild": "node scripts/verify-dist.mjs",
+    "build:site": "vite build --config vite.pages.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "src/**/*",
     "test/**/*",
     "vite.config.ts",
+    "vite.pages.config.ts",
     "vitest.config.ts",
     "vitest.layout.config.ts"
   ],

--- a/vite.pages.config.ts
+++ b/vite.pages.config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+import { defineConfig } from 'vite';
+
+// App-mode build of the workbench for GitHub Pages. Deliberately separate from
+// vite.config.ts: that one is lib-mode and guarded by verify-dist, this one
+// treats index.html as the entry and must never touch dist/. The relative base
+// keeps the built page servable from any subpath (project pages live under
+// /lcars-47/), so nothing here needs editing on a repo rename or custom domain.
+// Any resolve/define/css setting added to vite.config.ts that affects how the
+// workbench is served must be mirrored here, or make dev and the published
+// site silently diverge.
+export default defineConfig({
+  base: './',
+  build: {
+    outDir: 'site',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
Closes #38

Publishes the workbench as a live demo at https://no42-org.github.io/lcars-47/ (goes live on first merge to `main`).

## What changed

- **`vite.pages.config.ts`**: app-mode build of `index.html` into a gitignored `site/` with `base: './'`, so assets resolve from the `/lcars-47/` project-page subpath. Separate from the lib-mode `vite.config.ts` on purpose; the `build:site` script name does not match `build`, so the `postbuild` hook (`verify-dist`) keeps guarding only the library output.
- **`make site`**, appended to `make verify` after the existing targets (preserving the build-before-test ordering `test/dist.test.ts` depends on), so a workbench that no longer builds fails PRs. Docs in AGENTS.md and CONTRIBUTING.md updated to match.
- **`.github/workflows/pages.yml`**: deploy on push to `main` + `workflow_dispatch` via the official Pages actions (configure-pages v6.0.0, upload-pages-artifact v5.0.0, deploy-pages v5.0.0), SHA-pinned, least-privilege permissions, queue-not-cancel concurrency. Runs only `make site`; the header comment records that trusting main's gate is policy, not wiring.
- **README**: live-demo link next to the workbench recording.

## Repo side (already done)

- Pages enabled with source "GitHub Actions" (`build_type: workflow`).
- Repo homepage set to the Pages URL.

## Verification

- `site/` served under a `/lcars-47/` subpath in headless Chromium: frame renders, Antonio font loads, zero failed requests, zero page errors, all asset URLs relative.
- `dist/` checksums unchanged by the site build; `git status` stays clean.
- `make verify` passes end to end with the new step.
- actionlint clean; zizmor 1.29.0 (the CI-pinned version) reports no findings.
- Adversarial code review ran over the diff; its findings (tsconfig `include` gap for the new config, stale verify docs, overstated gate-coupling comments, config-divergence warning) are addressed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)