### PR TITLE
docs(readme): point the demo link at lcars-47.no42.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Authentic Star Trek LCARS (Library Computer Access / Retrieval System) user inte
 ![The LCARS 47 workbench: live telemetry driving readouts, bargraphs and status pills inside an elbow frame, cycling through the TNG, DS9, Nemesis and high-contrast era palettes](docs/workbench.gif)
 
 The workbench above is `index.html` in this repository, recorded live.
-[Try it in your browser](https://no42-org.github.io/lcars-47/) or run it locally with `make dev`.
+[Try it in your browser](https://lcars-47.no42.org/) or run it locally with `make dev`.
 
 ## Features
 


### PR DESCRIPTION
Closes #40

Swaps the README demo link to the custom domain `https://lcars-47.no42.org/`. The old `no42-org.github.io/lcars-47` URL 301-redirects there, so nothing breaks either way.

Repo-settings side (done outside this PR): custom domain set on Pages, org domain `no42.org` verified. Held for merge until the Let's Encrypt certificate is issued so the link never points at a TLS error; **Enforce HTTPS** gets enabled at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)