### PR TITLE
feat(release): publish to npmjs.org instead of GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write # create the release and upload assets
-      packages: write # publish to GitHub Packages
-      id-token: write # cosign keyless signing
+      id-token: write # cosign keyless signing and npm trusted publishing (OIDC)
       attestations: write # SLSA build provenance
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,14 +44,15 @@ jobs:
       #
       # package-manager-cache: false is required, not just omitting `cache:` —
       # setup-node v7 caches by default whenever a lockfile is present.
+      # No registry-url here on purpose: publishing uses npm trusted publishing
+      # (OIDC via id-token: write), and setup-node's registry-url writes an
+      # .npmrc referencing NODE_AUTH_TOKEN, which npm errors on when the
+      # variable is unset. The registry comes from publishConfig in
+      # package.json.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
-          # Writes the .npmrc that points the scope at GitHub Packages and
-          # reads NODE_AUTH_TOKEN when publishing.
-          registry-url: https://npm.pkg.github.com
-          scope: '@no42-org'
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -126,9 +126,12 @@ jobs:
       # Publishes the exact tarball that was checksummed, signed and attested,
       # rather than repacking, so the artifact users install is the one the
       # signature covers.
-      - name: Publish to GitHub Packages
+      #
+      # Auth is npm trusted publishing: the repo/workflow pair is registered as
+      # a trusted publisher on npmjs.com, npm exchanges the OIDC token itself,
+      # and provenance is generated automatically. No NODE_AUTH_TOKEN.
+      - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           # ./ prefix is required: npm reads a bare "release/x.tgz" as a git

--- a/README.md
+++ b/README.md
@@ -34,19 +34,7 @@ The workbench above is `index.html` in this repository, recorded live.
 
 ### Package Manager (ESM)
 
-The package is published to **GitHub Packages**. Point the scope at that registry once, in an `.npmrc` next to your `package.json`:
-
-```
-@no42-org:registry=https://npm.pkg.github.com
-```
-
-GitHub Packages requires authentication **even for public packages**, so you also need a personal access token with the `read:packages` scope:
-
-```
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-```
-
-Then install as usual:
+The package is published to **npmjs.org**, so no registry configuration or token is needed:
 
 ```bash
 npm install @no42-org/lcars-47
@@ -60,9 +48,9 @@ import '@no42-org/lcars-47/css';
 import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 ```
 
-### Standalone bundle (no build tooling, no account)
+### Standalone bundle (no build tooling)
 
-If you would rather not authenticate, the release assets are served anonymously. Grab the two files straight from a release:
+If you would rather skip npm entirely, grab the two files straight from a release:
 
 ```html
 <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.css" />

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,14 +87,16 @@ gh attestation verify no42-org-lcars-47-X.Y.Z.tgz --repo no42-org/lcars-47
 
 ## Where the package is published
 
-The release workflow publishes to **GitHub Packages** (`npm.pkg.github.com`) as its last step, after every other step has succeeded — publishing is the one action here that cannot be undone, since a version number cannot be reused.
+The release workflow publishes to **npmjs.org** as its last step, after every other step has succeeded.
+Publishing is the one action here that cannot be undone, since a version number cannot be reused.
 
-It publishes the **exact tarball** that was checksummed, signed and attested, rather than repacking, so what a user installs is what the signature covers. Authentication uses the built-in `GITHUB_TOKEN`; there is no registry secret to manage. Prerelease tags publish under the `next` dist-tag so they never become `latest`.
+It publishes the **exact tarball** that was checksummed, signed and attested, rather than repacking, so what a user installs is what the signature covers.
+Authentication uses **npm trusted publishing**: the repo and workflow are registered as a trusted publisher on npmjs.com, npm exchanges the workflow's OIDC token itself, and npm provenance is generated automatically.
+There is no registry secret to manage.
+Prerelease tags publish under the `next` dist-tag so they never become `latest`.
 
-Consumers must authenticate to install from GitHub Packages, **even though the package is public** — that is a registry limitation, not a licensing one. The README documents the `.npmrc` this needs, and points anyone who would rather not authenticate at the release assets, which serve anonymously.
+Publishing to npmjs.org also lights up the unpkg and jsDelivr CDN paths, which mirror npmjs.org.
 
 ## Not yet wired up
-
-**Publishing to npmjs.com.** Would make `npm install` work with no `.npmrc` and no token, and would light up the unpkg and jsDelivr CDN paths, which mirror npmjs.com only and cannot serve GitHub Packages. It needs an npm account and an `NPM_TOKEN` secret. Publish with `--provenance` so npm carries the same SLSA attestation this pipeline already produces.
 
 **Preview builds from `main`.** The audit checklist expects a rolling preview. This project ships no container image, so the useful equivalent is a `preview` prerelease refreshed on each push to `main`. Not implemented yet.

--- a/package.json
+++ b/package.json
@@ -56,8 +56,22 @@
     "vitest": "^4.1.10"
   },
   "license": "LGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/no42-org/lcars-47.git"
+  },
+  "homepage": "https://lcars-47.no42.org",
+  "bugs": "https://github.com/no42-org/lcars-47/issues",
+  "keywords": [
+    "lcars",
+    "web-components",
+    "lit",
+    "design-tokens",
+    "ui",
+    "star-trek"
+  ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "author": "Ronny Trommer <ronny@no42.org>",


### PR DESCRIPTION
Switches the publish target from GitHub Packages to registry.npmjs.org. Consumers can now `npm install @no42-org/lcars-47` with no `.npmrc` and no token, and the unpkg/jsDelivr CDN paths light up.

**Auth**: npm trusted publishing (OIDC). The repo/workflow pair is registered as a trusted publisher on npmjs.com, so there is no `NPM_TOKEN` secret to manage and npm provenance is generated automatically. `packages: write` and the setup-node `registry-url` are removed (the `.npmrc` setup-node writes references `NODE_AUTH_TOKEN`, which npm errors on when unset).

**package.json**: adds `repository` (required for npm provenance), `homepage`, `bugs`, `keywords`; `publishConfig.registry` now points at npmjs.org.

**Docs**: README installation section drops the GitHub Packages auth dance; RELEASING.md describes the new publish path and no longer lists npmjs.com under "Not yet wired up".

**Bootstrap already done**: 0.1.0 was published manually to create the package (trusted publishing cannot create a new package), and the trusted publisher is configured. From the next `v*` tag the workflow publishes on its own.

Verified: `make release-build` passes the full gate; `npm publish --dry-run` resolves to registry.npmjs.org with tag `latest` and public access; `npm view @no42-org/lcars-47` shows 0.1.0 live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)