### PR TITLE
feat(release): generate SBOM first-party and render an HTML report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,16 +81,18 @@ jobs:
       # This renders it as a self-contained HTML report. Both must exist before
       # checksums are computed, or they ship unverifiable.
       #
-      # image is pinned to a digest deliberately: the action's own resolution
-      # falls back to the mutable report-rc tag, and this job signs what it
-      # produces, so it must not pull a moving image. Dependabot bumps the
-      # action pin but not this digest; update it when bumping the action.
+      # image is pinned to the digest of the report image matching the action
+      # version: the action would resolve the report-0.7.1 tag itself, but a
+      # tag can be repointed, and this job signs what it produces, so it must
+      # not pull a moving image. Dependabot bumps the action pin but not this
+      # digest; update both together, and keep the trailing tag comment in
+      # sync so a reviewer can cross-reference it.
       - name: Render SBOM report
         uses: no42-org/blitsbom@b3cb2b1bdd5664193478acf04812251fdc8eb124 # v0.7.1
         with:
           sbom: release/sbom.cdx.json
           output: release/sbom-report.html
-          image: ghcr.io/no42-org/blitsbom@sha256:72ac31712ac30279ed4b297fbf6453182288862c678e8c77c83e70fb2ffb30b5
+          image: ghcr.io/no42-org/blitsbom@sha256:d7bb1cb75dc5444ea0e977b66a7860e9dc0a710812b2302bddd1d63a2af0d632 # report-0.7.1
 
       - name: Checksums and signature
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,20 @@ jobs:
 
       - run: make release-build
 
-      # SBOM must exist before checksums are computed, or it ships unverifiable.
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      # The SBOM itself comes out of make release-build (npm sbom, first-party).
+      # This renders it as a self-contained HTML report. Both must exist before
+      # checksums are computed, or they ship unverifiable.
+      #
+      # image is pinned to a digest deliberately: the action's own resolution
+      # falls back to the mutable report-rc tag, and this job signs what it
+      # produces, so it must not pull a moving image. Dependabot bumps the
+      # action pin but not this digest; update it when bumping the action.
+      - name: Render SBOM report
+        uses: no42-org/blitsbom@b3cb2b1bdd5664193478acf04812251fdc8eb124 # v0.7.1
         with:
-          path: .
-          output-file: release/sbom.spdx.json
+          sbom: release/sbom.cdx.json
+          output: release/sbom-report.html
+          image: ghcr.io/no42-org/blitsbom@sha256:72ac31712ac30279ed4b297fbf6453182288862c678e8c77c83e70fb2ffb30b5
 
       - name: Checksums and signature
         run: |

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ release-build: verify ## Assemble signed-release inputs into release/
 	$(NPM) pack --pack-destination release
 	# Standalone bundles for direct download / CDN mirroring.
 	cp dist/lcars.iife.js dist/lcars.css dist/index.d.ts release/
+	# SBOM of what ships (runtime tree only), generated first-party by npm so
+	# the release job needs no third-party tooling for it. CycloneDX rather
+	# than SPDX because the blitsbom VEX overlay is CycloneDX-only.
+	$(NPM) sbom --sbom-format cyclonedx --omit dev > release/sbom.cdx.json
 
 dev: node_modules ## Start the workbench dev server
 	$(NPM) run dev

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,7 +39,7 @@ A release is triggered by **pushing a `vX.Y.Z` tag**. Nothing else publishes.
    git push origin vX.Y.Z
    ```
 
-4. The `Release` workflow runs the same quality gates as CI, builds the artifacts, generates an SBOM, signs the checksums with cosign, attests build provenance, and creates a **draft** GitHub Release with everything attached.
+4. The `Release` workflow runs the same quality gates as CI, builds the artifacts (including a CycloneDX SBOM of the runtime dependency tree, generated first-party by `npm sbom` inside `make release-build`), renders the SBOM as a self-contained HTML report with [blitsbom](https://github.com/no42-org/blitsbom), signs the checksums with cosign, attests build provenance, and creates a **draft** GitHub Release with everything attached.
 5. Review the draft, add curated notes, and publish:
 
    ```bash
@@ -56,7 +56,8 @@ Prerelease tags (`vX.Y.Z-rc1`) are detected by the hyphen and marked `--prerelea
 | `lcars.iife.js` | Self-contained browser bundle for a `<script>` tag |
 | `lcars.css` | Standalone design tokens and layout stylesheet |
 | `index.d.ts` | Bundled TypeScript declarations for the whole public API |
-| `sbom.spdx.json` | SPDX software bill of materials |
+| `sbom.cdx.json` | CycloneDX software bill of materials (runtime dependencies) |
+| `sbom-report.html` | Self-contained HTML rendering of the SBOM, via blitsbom |
 | `checksums.txt` | SHA-256 of every other asset |
 | `checksums.txt.bundle` | cosign keyless Sigstore bundle (signature + certificate) |
 


### PR DESCRIPTION
Removes `anchore/sbom-action` from the release pipeline and adds a human-readable SBOM report rendered by [blitsbom](https://github.com/no42-org/blitsbom).

**Generation**: `npm sbom --sbom-format cyclonedx --omit dev` now runs inside `make release-build`, so CI keeps invoking only make targets and a local build produces the identical `sbom.cdx.json`. First-party (bundled with npm), deterministic, and the job holding `id-token: write` loses a third-party action. Scope is the runtime dependency tree (root + the lit family): what a consumer installs. Accepted trade-off: the bundled Antonio fonts leave the SBOM; `OFL.txt` still ships in the tarball.

**Rendering**: the `no42-org/blitsbom` action turns the SBOM into a self-contained `sbom-report.html` release asset. The action is SHA-pinned per repo convention, and its `image` input is pinned to the GHCR **digest** of `report-0.7.1` (with the tag in a trailing comment): the action would resolve that tag itself, but a tag can be repointed, and this signing pipeline must not pull a moving image. Dependabot bumps the action pin but not the digest; a workflow comment says to move both together.

Both artifacts land in `release/` before the checksum step, so they are covered by `checksums.txt`, the cosign bundle, and the existing upload loop unchanged.

**Verified**: `make release-build` green (full gate); SBOM is CycloneDX 1.5 with SPDX license IDs on all components; actionlint and zizmor clean; the pinned `report-0.7.1` image rendered the report locally (187 kB, self-contained, no external resources). Remaining check happens on the next release tag: both artifacts on the release page, listed in `checksums.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)