### PR TITLE
feat(release): carry the version in the SBOM artifact filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,19 @@ jobs:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Fail if the tag does not match the manifest version
+        id: version
         env:
           TAG: ${{ github.ref_name }}
         run: |
           # A v0.4.0 tag on a tree whose package.json says 0.3.0 ships a
           # bundle that self-reports the wrong version.
-          manifest="v$(node -p 'require("./package.json").version')"
-          if [ "$manifest" != "$TAG" ]; then
-            echo "tag $TAG does not match package.json ($manifest)" >&2
+          version="$(node -p 'require("./package.json").version')"
+          if [ "v$version" != "$TAG" ]; then
+            echo "tag $TAG does not match package.json (v$version)" >&2
             exit 1
           fi
+          # Exported for the versioned SBOM artifact names below.
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - run: make install
 
@@ -90,8 +93,8 @@ jobs:
       - name: Render SBOM report
         uses: no42-org/blitsbom@b3cb2b1bdd5664193478acf04812251fdc8eb124 # v0.7.1
         with:
-          sbom: release/sbom.cdx.json
-          output: release/sbom-report.html
+          sbom: release/lcars-47-${{ steps.version.outputs.version }}-sbom.cdx.json
+          output: release/lcars-47-${{ steps.version.outputs.version }}-sbom-report.html
           image: ghcr.io/no42-org/blitsbom@sha256:d7bb1cb75dc5444ea0e977b66a7860e9dc0a710812b2302bddd1d63a2af0d632 # report-0.7.1
 
       - name: Checksums and signature

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,10 @@ release-build: verify ## Assemble signed-release inputs into release/
 	cp dist/lcars.iife.js dist/lcars.css dist/index.d.ts release/
 	# SBOM of what ships (runtime tree only), generated first-party by npm so
 	# the release job needs no third-party tooling for it. CycloneDX rather
-	# than SPDX because the blitsbom VEX overlay is CycloneDX-only.
-	$(NPM) sbom --sbom-format cyclonedx --omit dev > release/sbom.cdx.json
+	# than SPDX because the blitsbom VEX overlay is CycloneDX-only. The
+	# filename carries the version, like the tarball next to it.
+	$(NPM) sbom --sbom-format cyclonedx --omit dev \
+		> "release/lcars-47-$$(node -p 'require("./package.json").version')-sbom.cdx.json"
 
 dev: node_modules ## Start the workbench dev server
 	$(NPM) run dev

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,8 +56,8 @@ Prerelease tags (`vX.Y.Z-rc1`) are detected by the hyphen and marked `--prerelea
 | `lcars.iife.js` | Self-contained browser bundle for a `<script>` tag |
 | `lcars.css` | Standalone design tokens and layout stylesheet |
 | `index.d.ts` | Bundled TypeScript declarations for the whole public API |
-| `sbom.cdx.json` | CycloneDX software bill of materials (runtime dependencies) |
-| `sbom-report.html` | Self-contained HTML rendering of the SBOM, via blitsbom |
+| `lcars-47-X.Y.Z-sbom.cdx.json` | CycloneDX software bill of materials (runtime dependencies) |
+| `lcars-47-X.Y.Z-sbom-report.html` | Self-contained HTML rendering of the SBOM, via blitsbom |
 | `checksums.txt` | SHA-256 of every other asset |
 | `checksums.txt.bundle` | cosign keyless Sigstore bundle (signature + certificate) |
 


### PR DESCRIPTION
Renames the SBOM release assets to `lcars-47-X.Y.Z-sbom.cdx.json` and `lcars-47-X.Y.Z-sbom-report.html`, matching the versioned npm tarball next to them, so a downloaded asset stays identifiable outside its release page.

The Makefile derives the version from `package.json`. The workflow reuses the existing tag-verification step (now `id: version`) to feed the blitsbom `sbom`/`output` inputs, so the filename version cannot disagree with the tag — the job fails on the mismatch before the output is ever used.

**Verified**: `make release-build` green (full gate) and produced `lcars-47-0.1.0-sbom.cdx.json`; the pinned `report-0.7.1` image rendered `lcars-47-0.1.0-sbom-report.html` from it locally; actionlint and zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)