### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ import { setLcarsTheme, playLcarsSound } from '@no42-org/lcars-47';
 If you would rather skip npm entirely, grab the two files straight from a release:
 
 ```html
-<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.css" />
-<script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.iife.js"></script>
+<link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.1/lcars.css" />
+<script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.1/lcars.iife.js"></script>
 ```
 
 All custom elements are registered automatically, and the utility functions are available under `window.Lcars`.
@@ -71,10 +71,10 @@ For production, download the files and serve them yourself rather than hot-linki
   <head>
     <meta charset="UTF-8" />
     <title>LCARS Console</title>
-    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.css" />
+    <link rel="stylesheet" href="https://github.com/no42-org/lcars-47/releases/download/v0.1.1/lcars.css" />
     <!-- The IIFE bundle is self-contained. The ESM entry externalizes lit, so
          it needs a bundler (or an import map) rather than a plain script tag. -->
-    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.0/lcars.iife.js"></script>
+    <script src="https://github.com/no42-org/lcars-47/releases/download/v0.1.1/lcars.iife.js"></script>
   </head>
   <body>
     <lcars-frame theme="tng">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@no42-org/lcars-47",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@no42-org/lcars-47",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Modern, accessible LCARS Web Component library and design token system",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #48.

Bumps the manifest to `0.1.1` so the tag and the package agree. The release workflow fails fast if they do not.

Nine commits since `v0.1.0`, none of them breaking, which the 0.x mapping in RELEASING.md floors at a patch bump. Only one of them reaches the shipped library: the readout/bargraph value-box reservation (#46). The rest are release pipeline, test tiers and site publishing.

Also moves the README standalone-bundle URLs from `v0.1.0` to `v0.1.1`. They are copy-paste instructions in the Quick Start, so leaving them behind hands new users the previous build. They 404 until the release is published, which is minutes after this merges.

`make verify`: 119 unit tests, 25 layout assertions, `verify-dist OK`.