### PR TITLE
fix(release): repin blitsbom to v0.8.2 and match the report image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,17 +85,19 @@ jobs:
       # checksums are computed, or they ship unverifiable.
       #
       # image is pinned to the digest of the report image matching the action
-      # version: the action would resolve the report-0.7.1 tag itself, but a
-      # tag can be repointed, and this job signs what it produces, so it must
+      # version: the action would resolve the matching report-* tag itself, but
+      # a tag can be repointed, and this job signs what it produces, so it must
       # not pull a moving image. Dependabot bumps the action pin but not this
       # digest; update both together, and keep the trailing tag comment in
-      # sync so a reviewer can cross-reference it.
+      # sync so a reviewer can cross-reference it. Nothing enforces the pairing
+      # here, and release.yml only runs on a tag, so a bump that moves one and
+      # not the other stays invisible until a release.
       - name: Render SBOM report
-        uses: no42-org/blitsbom@656cc261f9bfec14087c8a3a536f4195fc321c03 # v0.8.1
+        uses: no42-org/blitsbom@0ddd4fd19cc563e3e1c1e27f7be2ffc7225dca65 # v0.8.2
         with:
           sbom: release/lcars-47-${{ steps.version.outputs.version }}-sbom.cdx.json
           output: release/lcars-47-${{ steps.version.outputs.version }}-sbom-report.html
-          image: ghcr.io/no42-org/blitsbom@sha256:d7bb1cb75dc5444ea0e977b66a7860e9dc0a710812b2302bddd1d63a2af0d632 # report-0.7.1
+          image: ghcr.io/no42-org/blitsbom@sha256:2b1fdaa7760461b273f8c3d9e6bf0f48583b2e4916bebc61604e12cf38971002 # report-0.8.2
 
       - name: Checksums and signature
         run: |


### PR DESCRIPTION
Fixes #53.

The `Lint workflows` job has been red on `main` since #51. zizmor exits 13 on `release.yml:94`: the pin `656cc261f9bf # v0.8.1` no longer matches the `v0.8.1` tag, which upstream re-pointed to `2340603607fe`.

That SHA was never a release commit. It is a mid-stream dependabot commit that happened to be HEAD while a premature `v0.8.1` tag sat on it, and blitsbom moved the tag to its real release commit a day after #52 pinned it. Nothing here changed to turn the build red; the upstream tag moved under a pin CI re-validates on every push.

Fixing that surfaced a second break the lint gate cannot see: #52 bumped the action 0.7.1 to 0.8.1 but left `image:` at `report-0.7.1`. The step comment states the invariant, that the digest must match the action version and that Dependabot moves one and not the other, so they must be updated together. `release.yml` only runs on a tag push, so this would have stayed hidden until the next release.

## Change

Both pins go to the current release, v0.8.2, whose tag resolves cleanly:

- action to `0ddd4fd19cc563e3e1c1e27f7be2ffc7225dca65 # v0.8.2`
- report image to `sha256:2b1fdaa7760461b273f8c3d9e6bf0f48583b2e4916bebc61604e12cf38971002 # report-0.8.2`

v0.8.2 rather than the corrected v0.8.1 commit, so the two-pin coordination is not done twice; Dependabot would open the 0.8.2 bump next regardless. Both are dependency-refresh patches with no functional change.

The comment loses its hardcoded `report-0.7.1` reference, which drifts on every bump, and gains a note that the pairing is unenforced.

## Verification

Run with the exact versions CI pins, online audits on:

```
$ uvx zizmor==1.29.0 --gh-token=... .
No findings to report. Good job! (6 suppressed)
zizmor exit=0

$ docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint@sha256:b1934ee5f1c5... -color
actionlint exit=0
```

The other jobs in that run, `Typecheck, test and build` and `Cross-engine invariants`, were already green and this touches no source file.

## Not addressed

Nothing enforces the action/image pairing, so the next Dependabot bump reproduces the second problem silently. Noted in #53 for a follow-up guard rather than widening this fix.