### PR TITLE
ci(gates): check that action pins and their images agree

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -71,6 +71,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # Runs before the linters below because it needs neither a network pull
+      # nor node_modules. Covers what zizmor structurally cannot: zizmor
+      # resolves `uses:` pins against their tags, but never reads `with:`, so
+      # an image digest handed to an action goes unchecked. See #53.
+      - run: make verify-pins
+
       # docker:// refs pin by image digest, not commit SHA.
       - uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 NPM ?= npm
 
-.PHONY: help install install-browsers install-browsers-all typecheck test test-watch test-layout test-compat build site verify dev clean distclean
+.PHONY: help install install-browsers install-browsers-all typecheck test test-watch test-layout test-compat build site verify verify-pins dev clean distclean
 
 help: ## Show available targets
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -60,6 +60,12 @@ site: node_modules ## Build the workbench as a static site into site/ (GitHub Pa
 # ordering stays undisturbed; it catches workbench breakage in the PR gate,
 # since the Pages deploy workflow runs only make site and no other checks.
 verify: typecheck build test test-layout site ## Full gate: types, build, tests, dist, layout and site checks
+
+# Deliberately outside verify and free of the node_modules prerequisite: this
+# lints workflow text, not the library, and belongs with actionlint and zizmor
+# in the Lint workflows job. Node builtins only, so that job stays install-free.
+verify-pins: ## Check that action pins and the images passed to them agree
+	node scripts/verify-action-pins.mjs
 
 release-build: verify ## Assemble signed-release inputs into release/
 	rm -rf release && mkdir -p release

--- a/scripts/verify-action-pins.mjs
+++ b/scripts/verify-action-pins.mjs
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Ronny Trommer <ronny@no42.org>
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+// Workflow pin check: when a step pins an action by commit SHA and also hands
+// that same action a digest-pinned image, the two must name one version.
+//
+// Dependabot updates a `uses:` pin and its trailing comment. It does not touch
+// a digest sitting in `with:`, so a bump splits the pair and leaves the action
+// and the image a release apart. That shipped in #52 (action v0.8.1, image
+// report-0.7.1) and stayed invisible because release.yml only runs on a tag
+// push, so no gate ever evaluated the pair. See #53.
+//
+// zizmor resolves `uses:` pins against their upstream tags, which is what
+// caught the stale pin itself, but it does not read `with:` inputs. Nothing
+// else covers the pairing.
+//
+// Deliberately textual. Comments are not part of the YAML data model, so a
+// parser would discard the version markers this exists to compare. It proves
+// the two comments agree, not that either digest resolves upstream; verifying
+// the image digest against GHCR would need a registry token this gate does
+// not have.
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const baseDir =
+  typeof import.meta.dirname === 'string'
+    ? import.meta.dirname
+    : fileURLToPath(new URL('.', import.meta.url));
+
+const workflows = resolve(baseDir, '..', '.github', 'workflows');
+
+// `uses: owner/repo@<40-hex commit> # v1.2.3`, with or without the leading
+// `- `: the list item is usually `- name:`, leaving `uses:` a plain key. The
+// 40-hex bound keeps docker:// refs out, since those pin by 64-hex digest.
+const ACTION_PIN = /^\s*-?\s*uses:\s*([\w.-]+\/[\w./-]+)@([0-9a-f]{40})\b\s*(?:#\s*(.*?))?\s*$/;
+// `image: host/path@sha256:<64-hex> # report-1.2.3`, as a `with:` input.
+const IMAGE_PIN = /^\s*([\w-]+):\s*(\S+?)@sha256:([0-9a-f]{64})\b\s*(?:#\s*(.*?))?\s*$/;
+// A step is a list item keyed on one of the step-level fields. Anchoring on
+// these keeps nested sequences (an `args:` list, say) from opening a block.
+const STEP_START = /^(\s*)-\s+(?:name|uses|id|if|run|env|with):/;
+
+const semver = (comment) => comment?.match(/\d+\.\d+\.\d+/)?.[0];
+
+// Step blocks, as [start, end) line ranges. A block runs until the next step
+// item at the same or shallower indent, so a deeper nested list stays inside.
+function stepRanges(lines) {
+  const starts = [];
+  for (const [i, line] of lines.entries()) {
+    const match = STEP_START.exec(line);
+    if (match) starts.push({ index: i, indent: match[1].length });
+  }
+  return starts.map(({ index, indent }, n) => {
+    const next = starts.slice(n + 1).find((s) => s.indent <= indent);
+    return [index, next ? next.index : lines.length];
+  });
+}
+
+const errors = [];
+
+for (const file of readdirSync(workflows).filter((f) => /\.ya?ml$/.test(f))) {
+  const lines = readFileSync(resolve(workflows, file), 'utf8').split('\n');
+
+  for (const [start, end] of stepRanges(lines)) {
+    const block = lines.slice(start, end);
+
+    const actionLine = block.findIndex((l) => ACTION_PIN.test(l));
+    if (actionLine === -1) continue;
+
+    // `uses:` is excluded explicitly: a docker:// action ref is also a digest
+    // pin, but it is the step's action, not an image handed to one.
+    const images = block
+      .map((line, i) => ({ line, i }))
+      .filter(({ line }) => IMAGE_PIN.test(line) && IMAGE_PIN.exec(line)[1] !== 'uses');
+    if (images.length === 0) continue;
+
+    const [, action, , actionComment] = ACTION_PIN.exec(block[actionLine]);
+    const where = (i) => `${file}:${start + i + 1}`;
+    const actionVersion = semver(actionComment);
+
+    if (!actionVersion) {
+      errors.push(
+        `${where(actionLine)}: ${action} is pinned by SHA but its comment carries no version, ` +
+          `so the image pinned alongside it cannot be checked against anything`
+      );
+      continue;
+    }
+
+    for (const { line, i } of images) {
+      const [, key, image, , comment] = IMAGE_PIN.exec(line);
+      const imageVersion = semver(comment);
+
+      if (!imageVersion) {
+        errors.push(
+          `${where(i)}: ${key} pins ${image} by digest with no version comment; ` +
+            `a reviewer cannot tell whether it matches ${action} ${actionVersion}`
+        );
+      } else if (imageVersion !== actionVersion) {
+        errors.push(
+          `${where(i)}: ${key} is ${image} ${imageVersion} but the step runs ${action} ` +
+            `${actionVersion} (${where(actionLine)}); bump the digest and its comment together`
+        );
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Action and image pins disagree:\n');
+  for (const error of errors) console.error(`  ${error}`);
+  console.error('');
+  process.exit(1);
+}
+
+console.log('Action and image pins agree.');


### PR DESCRIPTION
Closes #55. Follow-up to #53, which fixed the drift but left the gap that allows it.

`release.yml` pins `no42-org/blitsbom` by SHA and separately hands it a digest-pinned `image:`. The step comment says the two must move together, and nothing enforced it, so #52 bumped the action to `v0.8.1` and left the image at `report-0.7.1`.

Two things kept that invisible. zizmor resolves `uses:` pins against their upstream tags, which is what caught the stale pin in #53, but it never reads `with:` inputs, so an image digest handed to an action is outside what it audits. And `release.yml` runs only on a tag push, so no PR gate evaluated the pair at all.

## Change

`scripts/verify-action-pins.mjs`: for any step that pins an action by SHA and also passes a digest-pinned image, the version in the two trailing comments must agree. A missing version comment on either side fails too, since an unlabelled digest cannot be reviewed.

Wired in as `make verify-pins`, called from the existing `Lint workflows` job so CI keeps invoking make rather than tooling directly. It runs before actionlint and zizmor because it needs neither a network pull nor `node_modules`. Node builtins only, and no `node_modules` prerequisite on the target, so that job stays install-free (`setup-node`, no `npm ci`).

Textual rather than parsed on purpose: comments are not part of the YAML data model, so a YAML parser would discard the version markers this compares.

## What it does not prove

It checks that the two comments agree, not that either digest resolves to that version upstream. Verifying the image against GHCR needs a registry token this gate does not have, and the repo is private. zizmor already covers the upstream half for the `uses:` pin. Stated in the script header rather than left for someone to discover.

## Verification

Against a copy of `.github` with the fault reinjected three ways. Clean tree passes; each fault fails with the offending `file:line`.

```
=== POSITIVE: real repo, pins agree ===
Action and image pins agree.
exit=0

=== NEG 1: the exact #52 bug (image a release behind) ===
  release.yml:100: image is ghcr.io/no42-org/blitsbom 0.7.1 but the step runs
  no42-org/blitsbom 0.8.2 (release.yml:96); bump the digest and its comment together
exit=1

=== NEG 2: image digest pinned with no version comment ===
  release.yml:100: image pins ghcr.io/no42-org/blitsbom by digest with no version
  comment; a reviewer cannot tell whether it matches no42-org/blitsbom 0.8.2
exit=1

=== NEG 3: action pin with no version comment ===
  release.yml:96: no42-org/blitsbom is pinned by SHA but its comment carries no
  version, so the image pinned alongside it cannot be checked against anything
exit=1
```

An early version of the check passed NEG 1, because the regex required a leading `- ` on the `uses:` line when the list item is actually `- name:`. The negative fixtures are what caught it.

No false positives across all eight workflow files, and both existing linters still pass at the versions CI pins: zizmor 1.29.0 exit 0, actionlint exit 0.